### PR TITLE
Palix dogwood social message edits

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -185,53 +185,69 @@ th {
     color: #000 !important;
     background: transparent !important;
     box-shadow: none !important; }
+
   a,
   a:visited {
     text-decoration: underline; }
+
   a[href]:after {
     content: " (" attr(href) ")"; }
+
   abbr[title]:after {
     content: " (" attr(title) ")"; }
+
   a[href^="javascript:"]:after,
   a[href^="#"]:after {
     content: ""; }
+
   pre,
   blockquote {
     border: 1px solid #999;
     page-break-inside: avoid; }
+
   thead {
     display: table-header-group; }
+
   tr,
   img {
     page-break-inside: avoid; }
+
   img {
     max-width: 100% !important; }
+
   p,
   h2,
   h3 {
     orphans: 3;
     widows: 3; }
+
   h2,
   h3 {
     page-break-after: avoid; }
+
   select {
     background: #fff !important; }
+
   .navbar {
     display: none; }
+
   .table td,
   .table th {
     background-color: #fff !important; }
+
   .btn > .caret,
   .dropup > .btn > .caret {
     border-top-color: #000 !important; }
+
   .label {
     border: 1px solid #000; }
+
   .table {
     border-collapse: collapse !important; }
+
   .table-bordered th,
   .table-bordered td {
     border: 1px solid #ddd !important; } }
-
 * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -519,321 +535,471 @@ hr {
 @media (min-width: 768px) {
   .col-sm-12, .col-sm-11, .col-sm-10, .col-sm-9, .col-sm-8, .col-sm-7, .col-sm-6, .col-sm-5, .col-sm-4, .col-sm-3, .col-sm-2, .col-sm-1 {
     float: left; }
+
   .col-sm-1 {
     width: 8.33333%; }
+
   .col-sm-2 {
     width: 16.66667%; }
+
   .col-sm-3 {
     width: 25%; }
+
   .col-sm-4 {
     width: 33.33333%; }
+
   .col-sm-5 {
     width: 41.66667%; }
+
   .col-sm-6 {
     width: 50%; }
+
   .col-sm-7 {
     width: 58.33333%; }
+
   .col-sm-8 {
     width: 66.66667%; }
+
   .col-sm-9 {
     width: 75%; }
+
   .col-sm-10 {
     width: 83.33333%; }
+
   .col-sm-11 {
     width: 91.66667%; }
+
   .col-sm-12 {
     width: 100%; }
+
   .col-sm-pull-0 {
     right: 0%; }
+
   .col-sm-pull-1 {
     right: 8.33333%; }
+
   .col-sm-pull-2 {
     right: 16.66667%; }
+
   .col-sm-pull-3 {
     right: 25%; }
+
   .col-sm-pull-4 {
     right: 33.33333%; }
+
   .col-sm-pull-5 {
     right: 41.66667%; }
+
   .col-sm-pull-6 {
     right: 50%; }
+
   .col-sm-pull-7 {
     right: 58.33333%; }
+
   .col-sm-pull-8 {
     right: 66.66667%; }
+
   .col-sm-pull-9 {
     right: 75%; }
+
   .col-sm-pull-10 {
     right: 83.33333%; }
+
   .col-sm-pull-11 {
     right: 91.66667%; }
+
   .col-sm-pull-12 {
     right: 100%; }
+
   .col-sm-push-0 {
     left: 0%; }
+
   .col-sm-push-1 {
     left: 8.33333%; }
+
   .col-sm-push-2 {
     left: 16.66667%; }
+
   .col-sm-push-3 {
     left: 25%; }
+
   .col-sm-push-4 {
     left: 33.33333%; }
+
   .col-sm-push-5 {
     left: 41.66667%; }
+
   .col-sm-push-6 {
     left: 50%; }
+
   .col-sm-push-7 {
     left: 58.33333%; }
+
   .col-sm-push-8 {
     left: 66.66667%; }
+
   .col-sm-push-9 {
     left: 75%; }
+
   .col-sm-push-10 {
     left: 83.33333%; }
+
   .col-sm-push-11 {
     left: 91.66667%; }
+
   .col-sm-push-12 {
     left: 100%; }
+
   .col-sm-offset-0 {
     margin-left: 0%; }
+
   .col-sm-offset-1 {
     margin-left: 8.33333%; }
+
   .col-sm-offset-2 {
     margin-left: 16.66667%; }
+
   .col-sm-offset-3 {
     margin-left: 25%; }
+
   .col-sm-offset-4 {
     margin-left: 33.33333%; }
+
   .col-sm-offset-5 {
     margin-left: 41.66667%; }
+
   .col-sm-offset-6 {
     margin-left: 50%; }
+
   .col-sm-offset-7 {
     margin-left: 58.33333%; }
+
   .col-sm-offset-8 {
     margin-left: 66.66667%; }
+
   .col-sm-offset-9 {
     margin-left: 75%; }
+
   .col-sm-offset-10 {
     margin-left: 83.33333%; }
+
   .col-sm-offset-11 {
     margin-left: 91.66667%; }
+
   .col-sm-offset-12 {
     margin-left: 100%; } }
-
 @media (min-width: 992px) {
   .col-md-12, .col-md-11, .col-md-10, .col-md-9, .col-md-8, .col-md-7, .col-md-6, .col-md-5, .col-md-4, .col-md-3, .col-md-2, .col-md-1 {
     float: left; }
+
   .col-md-1 {
     width: 8.33333%; }
+
   .col-md-2 {
     width: 16.66667%; }
+
   .col-md-3 {
     width: 25%; }
+
   .col-md-4 {
     width: 33.33333%; }
+
   .col-md-5 {
     width: 41.66667%; }
+
   .col-md-6 {
     width: 50%; }
+
   .col-md-7 {
     width: 58.33333%; }
+
   .col-md-8 {
     width: 66.66667%; }
+
   .col-md-9 {
     width: 75%; }
+
   .col-md-10 {
     width: 83.33333%; }
+
   .col-md-11 {
     width: 91.66667%; }
+
   .col-md-12 {
     width: 100%; }
+
   .col-md-pull-0 {
     right: 0%; }
+
   .col-md-pull-1 {
     right: 8.33333%; }
+
   .col-md-pull-2 {
     right: 16.66667%; }
+
   .col-md-pull-3 {
     right: 25%; }
+
   .col-md-pull-4 {
     right: 33.33333%; }
+
   .col-md-pull-5 {
     right: 41.66667%; }
+
   .col-md-pull-6 {
     right: 50%; }
+
   .col-md-pull-7 {
     right: 58.33333%; }
+
   .col-md-pull-8 {
     right: 66.66667%; }
+
   .col-md-pull-9 {
     right: 75%; }
+
   .col-md-pull-10 {
     right: 83.33333%; }
+
   .col-md-pull-11 {
     right: 91.66667%; }
+
   .col-md-pull-12 {
     right: 100%; }
+
   .col-md-push-0 {
     left: 0%; }
+
   .col-md-push-1 {
     left: 8.33333%; }
+
   .col-md-push-2 {
     left: 16.66667%; }
+
   .col-md-push-3 {
     left: 25%; }
+
   .col-md-push-4 {
     left: 33.33333%; }
+
   .col-md-push-5 {
     left: 41.66667%; }
+
   .col-md-push-6 {
     left: 50%; }
+
   .col-md-push-7 {
     left: 58.33333%; }
+
   .col-md-push-8 {
     left: 66.66667%; }
+
   .col-md-push-9 {
     left: 75%; }
+
   .col-md-push-10 {
     left: 83.33333%; }
+
   .col-md-push-11 {
     left: 91.66667%; }
+
   .col-md-push-12 {
     left: 100%; }
+
   .col-md-offset-0 {
     margin-left: 0%; }
+
   .col-md-offset-1 {
     margin-left: 8.33333%; }
+
   .col-md-offset-2 {
     margin-left: 16.66667%; }
+
   .col-md-offset-3 {
     margin-left: 25%; }
+
   .col-md-offset-4 {
     margin-left: 33.33333%; }
+
   .col-md-offset-5 {
     margin-left: 41.66667%; }
+
   .col-md-offset-6 {
     margin-left: 50%; }
+
   .col-md-offset-7 {
     margin-left: 58.33333%; }
+
   .col-md-offset-8 {
     margin-left: 66.66667%; }
+
   .col-md-offset-9 {
     margin-left: 75%; }
+
   .col-md-offset-10 {
     margin-left: 83.33333%; }
+
   .col-md-offset-11 {
     margin-left: 91.66667%; }
+
   .col-md-offset-12 {
     margin-left: 100%; } }
-
 @media (min-width: 1200px) {
   .col-lg-12, .col-lg-11, .col-lg-10, .col-lg-9, .col-lg-8, .col-lg-7, .col-lg-6, .col-lg-5, .col-lg-4, .col-lg-3, .col-lg-2, .col-lg-1 {
     float: left; }
+
   .col-lg-1 {
     width: 8.33333%; }
+
   .col-lg-2 {
     width: 16.66667%; }
+
   .col-lg-3 {
     width: 25%; }
+
   .col-lg-4 {
     width: 33.33333%; }
+
   .col-lg-5 {
     width: 41.66667%; }
+
   .col-lg-6 {
     width: 50%; }
+
   .col-lg-7 {
     width: 58.33333%; }
+
   .col-lg-8 {
     width: 66.66667%; }
+
   .col-lg-9 {
     width: 75%; }
+
   .col-lg-10 {
     width: 83.33333%; }
+
   .col-lg-11 {
     width: 91.66667%; }
+
   .col-lg-12 {
     width: 100%; }
+
   .col-lg-pull-0 {
     right: 0%; }
+
   .col-lg-pull-1 {
     right: 8.33333%; }
+
   .col-lg-pull-2 {
     right: 16.66667%; }
+
   .col-lg-pull-3 {
     right: 25%; }
+
   .col-lg-pull-4 {
     right: 33.33333%; }
+
   .col-lg-pull-5 {
     right: 41.66667%; }
+
   .col-lg-pull-6 {
     right: 50%; }
+
   .col-lg-pull-7 {
     right: 58.33333%; }
+
   .col-lg-pull-8 {
     right: 66.66667%; }
+
   .col-lg-pull-9 {
     right: 75%; }
+
   .col-lg-pull-10 {
     right: 83.33333%; }
+
   .col-lg-pull-11 {
     right: 91.66667%; }
+
   .col-lg-pull-12 {
     right: 100%; }
+
   .col-lg-push-0 {
     left: 0%; }
+
   .col-lg-push-1 {
     left: 8.33333%; }
+
   .col-lg-push-2 {
     left: 16.66667%; }
+
   .col-lg-push-3 {
     left: 25%; }
+
   .col-lg-push-4 {
     left: 33.33333%; }
+
   .col-lg-push-5 {
     left: 41.66667%; }
+
   .col-lg-push-6 {
     left: 50%; }
+
   .col-lg-push-7 {
     left: 58.33333%; }
+
   .col-lg-push-8 {
     left: 66.66667%; }
+
   .col-lg-push-9 {
     left: 75%; }
+
   .col-lg-push-10 {
     left: 83.33333%; }
+
   .col-lg-push-11 {
     left: 91.66667%; }
+
   .col-lg-push-12 {
     left: 100%; }
+
   .col-lg-offset-0 {
     margin-left: 0%; }
+
   .col-lg-offset-1 {
     margin-left: 8.33333%; }
+
   .col-lg-offset-2 {
     margin-left: 16.66667%; }
+
   .col-lg-offset-3 {
     margin-left: 25%; }
+
   .col-lg-offset-4 {
     margin-left: 33.33333%; }
+
   .col-lg-offset-5 {
     margin-left: 41.66667%; }
+
   .col-lg-offset-6 {
     margin-left: 50%; }
+
   .col-lg-offset-7 {
     margin-left: 58.33333%; }
+
   .col-lg-offset-8 {
     margin-left: 66.66667%; }
+
   .col-lg-offset-9 {
     margin-left: 75%; }
+
   .col-lg-offset-10 {
     margin-left: 83.33333%; }
+
   .col-lg-offset-11 {
     margin-left: 91.66667%; }
+
   .col-lg-offset-12 {
     margin-left: 100%; } }
-
 .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
@@ -928,7 +1094,6 @@ hr {
 
 .open > .dropdown-menu {
   display: block; }
-
 .open > a {
   outline: 0; }
 
@@ -964,7 +1129,6 @@ hr {
   border-top: 0;
   border-bottom: 4px solid;
   content: ""; }
-
 .dropup .dropdown-menu,
 .navbar-fixed-bottom .dropdown .dropdown-menu {
   top: auto;
@@ -978,7 +1142,6 @@ hr {
   .navbar-right .dropdown-menu-left {
     left: 0;
     right: auto; } }
-
 .modal-open {
   overflow: hidden; }
 
@@ -1076,14 +1239,16 @@ hr {
   .modal-dialog {
     width: 600px;
     margin: 30px auto; }
+
   .modal-content {
     -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5); }
+
   .modal-sm {
     width: 300px; }
+
   .modal-lg {
     width: 900px; } }
-
 /*!
 Animate.css - http://daneden.me/animate
 Licensed under the MIT license - http://opensource.org/licenses/MIT
@@ -1133,7 +1298,6 @@ Copyright (c) 2015 Daniel Eden
   90% {
     -webkit-transform: translate3d(0, -4px, 0);
     transform: translate3d(0, -4px, 0); } }
-
 @keyframes bounce {
   from, 20%, 53%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1153,7 +1317,6 @@ Copyright (c) 2015 Daniel Eden
   90% {
     -webkit-transform: translate3d(0, -4px, 0);
     transform: translate3d(0, -4px, 0); } }
-
 .bounce {
   -webkit-animation-name: bounce;
   animation-name: bounce;
@@ -1165,13 +1328,11 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1; }
   25%, 75% {
     opacity: 0; } }
-
 @keyframes flash {
   from, 50%, to {
     opacity: 1; }
   25%, 75% {
     opacity: 0; } }
-
 .flash {
   -webkit-animation-name: flash;
   animation-name: flash; }
@@ -1187,7 +1348,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
-
 @keyframes pulse {
   from {
     -webkit-transform: scale3d(1, 1, 1);
@@ -1198,7 +1358,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
-
 .pulse {
   -webkit-animation-name: pulse;
   animation-name: pulse; }
@@ -1225,7 +1384,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
-
 @keyframes rubberBand {
   from {
     -webkit-transform: scale3d(1, 1, 1);
@@ -1248,7 +1406,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
-
 .rubberBand {
   -webkit-animation-name: rubberBand;
   animation-name: rubberBand; }
@@ -1263,7 +1420,6 @@ Copyright (c) 2015 Daniel Eden
   20%, 40%, 60%, 80% {
     -webkit-transform: translate3d(10px, 0, 0);
     transform: translate3d(10px, 0, 0); } }
-
 @keyframes shake {
   from, to {
     -webkit-transform: translate3d(0, 0, 0);
@@ -1274,7 +1430,6 @@ Copyright (c) 2015 Daniel Eden
   20%, 40%, 60%, 80% {
     -webkit-transform: translate3d(10px, 0, 0);
     transform: translate3d(10px, 0, 0); } }
-
 .shake {
   -webkit-animation-name: shake;
   animation-name: shake; }
@@ -1295,7 +1450,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: rotate3d(0, 0, 1, 0deg);
     transform: rotate3d(0, 0, 1, 0deg); } }
-
 @keyframes swing {
   20% {
     -webkit-transform: rotate3d(0, 0, 1, 15deg);
@@ -1312,7 +1466,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: rotate3d(0, 0, 1, 0deg);
     transform: rotate3d(0, 0, 1, 0deg); } }
-
 .swing {
   -webkit-transform-origin: top center;
   transform-origin: top center;
@@ -1335,7 +1488,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
-
 @keyframes tada {
   from {
     -webkit-transform: scale3d(1, 1, 1);
@@ -1352,7 +1504,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
-
 .tada {
   -webkit-animation-name: tada;
   animation-name: tada; }
@@ -1380,7 +1531,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes wobble {
   from {
     -webkit-transform: none;
@@ -1403,7 +1553,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
-
 .wobble {
   -webkit-animation-name: wobble;
   animation-name: wobble; }
@@ -1428,12 +1577,11 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: skewX(-0.78125deg) skewY(-0.78125deg);
     transform: skewX(-0.78125deg) skewY(-0.78125deg); }
   77.7% {
-    -webkit-transform: skewX(0.39062deg) skewY(0.39062deg);
-    transform: skewX(0.39062deg) skewY(0.39062deg); }
+    -webkit-transform: skewX(0.39063deg) skewY(0.39063deg);
+    transform: skewX(0.39063deg) skewY(0.39063deg); }
   88.8% {
     -webkit-transform: skewX(-0.19531deg) skewY(-0.19531deg);
     transform: skewX(-0.19531deg) skewY(-0.19531deg); } }
-
 @keyframes jello {
   from, 11.1%, to {
     -webkit-transform: none;
@@ -1454,12 +1602,11 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: skewX(-0.78125deg) skewY(-0.78125deg);
     transform: skewX(-0.78125deg) skewY(-0.78125deg); }
   77.7% {
-    -webkit-transform: skewX(0.39062deg) skewY(0.39062deg);
-    transform: skewX(0.39062deg) skewY(0.39062deg); }
+    -webkit-transform: skewX(0.39063deg) skewY(0.39063deg);
+    transform: skewX(0.39063deg) skewY(0.39063deg); }
   88.8% {
     -webkit-transform: skewX(-0.19531deg) skewY(-0.19531deg);
     transform: skewX(-0.19531deg) skewY(-0.19531deg); } }
-
 .jello {
   -webkit-animation-name: jello;
   animation-name: jello;
@@ -1491,7 +1638,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
-
 @keyframes bounceIn {
   from, 20%, 40%, 60%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1517,7 +1663,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
-
 .bounceIn {
   -webkit-animation-name: bounceIn;
   animation-name: bounceIn; }
@@ -1543,7 +1688,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes bounceInDown {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1565,7 +1709,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
-
 .bounceInDown {
   -webkit-animation-name: bounceInDown;
   animation-name: bounceInDown; }
@@ -1591,7 +1734,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes bounceInLeft {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1613,7 +1755,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
-
 .bounceInLeft {
   -webkit-animation-name: bounceInLeft;
   animation-name: bounceInLeft; }
@@ -1639,7 +1780,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes bounceInRight {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1661,7 +1801,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
-
 .bounceInRight {
   -webkit-animation-name: bounceInRight;
   animation-name: bounceInRight; }
@@ -1687,7 +1826,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
-
 @keyframes bounceInUp {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1709,7 +1847,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
-
 .bounceInUp {
   -webkit-animation-name: bounceInUp;
   animation-name: bounceInUp; }
@@ -1726,7 +1863,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: scale3d(0.3, 0.3, 0.3);
     transform: scale3d(0.3, 0.3, 0.3); } }
-
 @keyframes bounceOut {
   20% {
     -webkit-transform: scale3d(0.9, 0.9, 0.9);
@@ -1739,7 +1875,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: scale3d(0.3, 0.3, 0.3);
     transform: scale3d(0.3, 0.3, 0.3); } }
-
 .bounceOut {
   -webkit-animation-name: bounceOut;
   animation-name: bounceOut; }
@@ -1756,7 +1891,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
-
 @keyframes bounceOutDown {
   20% {
     -webkit-transform: translate3d(0, 10px, 0);
@@ -1769,7 +1903,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
-
 .bounceOutDown {
   -webkit-animation-name: bounceOutDown;
   animation-name: bounceOutDown; }
@@ -1783,7 +1916,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
-
 @keyframes bounceOutLeft {
   20% {
     opacity: 1;
@@ -1793,7 +1925,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
-
 .bounceOutLeft {
   -webkit-animation-name: bounceOutLeft;
   animation-name: bounceOutLeft; }
@@ -1807,7 +1938,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
-
 @keyframes bounceOutRight {
   20% {
     opacity: 1;
@@ -1817,7 +1947,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
-
 .bounceOutRight {
   -webkit-animation-name: bounceOutRight;
   animation-name: bounceOutRight; }
@@ -1834,7 +1963,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
-
 @keyframes bounceOutUp {
   20% {
     -webkit-transform: translate3d(0, -10px, 0);
@@ -1847,7 +1975,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
-
 .bounceOutUp {
   -webkit-animation-name: bounceOutUp;
   animation-name: bounceOutUp; }
@@ -1857,13 +1984,11 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0; }
   to {
     opacity: 1; } }
-
 @keyframes fadeIn {
   from {
     opacity: 0; }
   to {
     opacity: 1; } }
-
 .fadeIn {
   -webkit-animation-name: fadeIn;
   animation-name: fadeIn; }
@@ -1877,7 +2002,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes fadeInDown {
   from {
     opacity: 0;
@@ -1887,7 +2011,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 .fadeInDown {
   -webkit-animation-name: fadeInDown;
   animation-name: fadeInDown; }
@@ -1901,7 +2024,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes fadeInDownBig {
   from {
     opacity: 0;
@@ -1911,7 +2033,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 .fadeInDownBig {
   -webkit-animation-name: fadeInDownBig;
   animation-name: fadeInDownBig; }
@@ -1925,7 +2046,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes fadeInLeft {
   from {
     opacity: 0;
@@ -1935,7 +2055,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 .fadeInLeft {
   -webkit-animation-name: fadeInLeft;
   animation-name: fadeInLeft; }
@@ -1949,7 +2068,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes fadeInLeftBig {
   from {
     opacity: 0;
@@ -1959,7 +2077,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 .fadeInLeftBig {
   -webkit-animation-name: fadeInLeftBig;
   animation-name: fadeInLeftBig; }
@@ -1973,7 +2090,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes fadeInRight {
   from {
     opacity: 0;
@@ -1983,7 +2099,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 .fadeInRight {
   -webkit-animation-name: fadeInRight;
   animation-name: fadeInRight; }
@@ -1997,7 +2112,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes fadeInRightBig {
   from {
     opacity: 0;
@@ -2007,7 +2121,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 .fadeInRightBig {
   -webkit-animation-name: fadeInRightBig;
   animation-name: fadeInRightBig; }
@@ -2021,7 +2134,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes fadeInUp {
   from {
     opacity: 0;
@@ -2031,7 +2143,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 .fadeInUp {
   -webkit-animation-name: fadeInUp;
   animation-name: fadeInUp; }
@@ -2045,7 +2156,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes fadeInUpBig {
   from {
     opacity: 0;
@@ -2055,7 +2165,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 .fadeInUpBig {
   -webkit-animation-name: fadeInUpBig;
   animation-name: fadeInUpBig; }
@@ -2065,13 +2174,11 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1; }
   to {
     opacity: 0; } }
-
 @keyframes fadeOut {
   from {
     opacity: 1; }
   to {
     opacity: 0; } }
-
 .fadeOut {
   -webkit-animation-name: fadeOut;
   animation-name: fadeOut; }
@@ -2083,7 +2190,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
-
 @keyframes fadeOutDown {
   from {
     opacity: 1; }
@@ -2091,7 +2197,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
-
 .fadeOutDown {
   -webkit-animation-name: fadeOutDown;
   animation-name: fadeOutDown; }
@@ -2103,7 +2208,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
-
 @keyframes fadeOutDownBig {
   from {
     opacity: 1; }
@@ -2111,7 +2215,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
-
 .fadeOutDownBig {
   -webkit-animation-name: fadeOutDownBig;
   animation-name: fadeOutDownBig; }
@@ -2123,7 +2226,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
-
 @keyframes fadeOutLeft {
   from {
     opacity: 1; }
@@ -2131,7 +2233,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
-
 .fadeOutLeft {
   -webkit-animation-name: fadeOutLeft;
   animation-name: fadeOutLeft; }
@@ -2143,7 +2244,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
-
 @keyframes fadeOutLeftBig {
   from {
     opacity: 1; }
@@ -2151,7 +2251,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
-
 .fadeOutLeftBig {
   -webkit-animation-name: fadeOutLeftBig;
   animation-name: fadeOutLeftBig; }
@@ -2163,7 +2262,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
-
 @keyframes fadeOutRight {
   from {
     opacity: 1; }
@@ -2171,7 +2269,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
-
 .fadeOutRight {
   -webkit-animation-name: fadeOutRight;
   animation-name: fadeOutRight; }
@@ -2183,7 +2280,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
-
 @keyframes fadeOutRightBig {
   from {
     opacity: 1; }
@@ -2191,7 +2287,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
-
 .fadeOutRightBig {
   -webkit-animation-name: fadeOutRightBig;
   animation-name: fadeOutRightBig; }
@@ -2203,7 +2298,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
-
 @keyframes fadeOutUp {
   from {
     opacity: 1; }
@@ -2211,7 +2305,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
-
 .fadeOutUp {
   -webkit-animation-name: fadeOutUp;
   animation-name: fadeOutUp; }
@@ -2223,7 +2316,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
-
 @keyframes fadeOutUpBig {
   from {
     opacity: 1; }
@@ -2231,7 +2323,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
-
 .fadeOutUpBig {
   -webkit-animation-name: fadeOutUpBig;
   animation-name: fadeOutUpBig; }
@@ -2262,7 +2353,6 @@ Copyright (c) 2015 Daniel Eden
     transform: perspective(400px);
     -webkit-animation-timing-function: ease-in;
     animation-timing-function: ease-in; } }
-
 @keyframes flip {
   from {
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, -360deg);
@@ -2289,7 +2379,6 @@ Copyright (c) 2015 Daniel Eden
     transform: perspective(400px);
     -webkit-animation-timing-function: ease-in;
     animation-timing-function: ease-in; } }
-
 .animated.flip {
   -webkit-backface-visibility: visible;
   backface-visibility: visible;
@@ -2318,7 +2407,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
-
 @keyframes flipInX {
   from {
     -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
@@ -2341,7 +2429,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
-
 .flipInX {
   -webkit-backface-visibility: visible !important;
   backface-visibility: visible !important;
@@ -2370,7 +2457,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
-
 @keyframes flipInY {
   from {
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
@@ -2393,7 +2479,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
-
 .flipInY {
   -webkit-backface-visibility: visible !important;
   backface-visibility: visible !important;
@@ -2412,7 +2497,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     opacity: 0; } }
-
 @keyframes flipOutX {
   from {
     -webkit-transform: perspective(400px);
@@ -2425,7 +2509,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     opacity: 0; } }
-
 .flipOutX {
   -webkit-animation-name: flipOutX;
   animation-name: flipOutX;
@@ -2444,7 +2527,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     opacity: 0; } }
-
 @keyframes flipOutY {
   from {
     -webkit-transform: perspective(400px);
@@ -2457,7 +2539,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     opacity: 0; } }
-
 .flipOutY {
   -webkit-backface-visibility: visible !important;
   backface-visibility: visible !important;
@@ -2481,7 +2562,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 @keyframes lightSpeedIn {
   from {
     -webkit-transform: translate3d(100%, 0, 0) skewX(-30deg);
@@ -2499,7 +2579,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 .lightSpeedIn {
   -webkit-animation-name: lightSpeedIn;
   animation-name: lightSpeedIn;
@@ -2513,7 +2592,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(100%, 0, 0) skewX(30deg);
     transform: translate3d(100%, 0, 0) skewX(30deg);
     opacity: 0; } }
-
 @keyframes lightSpeedOut {
   from {
     opacity: 1; }
@@ -2521,7 +2599,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(100%, 0, 0) skewX(30deg);
     transform: translate3d(100%, 0, 0) skewX(30deg);
     opacity: 0; } }
-
 .lightSpeedOut {
   -webkit-animation-name: lightSpeedOut;
   animation-name: lightSpeedOut;
@@ -2541,7 +2618,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 @keyframes rotateIn {
   from {
     -webkit-transform-origin: center;
@@ -2555,7 +2631,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 .rotateIn {
   -webkit-animation-name: rotateIn;
   animation-name: rotateIn; }
@@ -2573,7 +2648,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 @keyframes rotateInDownLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2587,7 +2661,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 .rotateInDownLeft {
   -webkit-animation-name: rotateInDownLeft;
   animation-name: rotateInDownLeft; }
@@ -2605,7 +2678,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 @keyframes rotateInDownRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2619,7 +2691,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 .rotateInDownRight {
   -webkit-animation-name: rotateInDownRight;
   animation-name: rotateInDownRight; }
@@ -2637,7 +2708,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 @keyframes rotateInUpLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2651,7 +2721,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 .rotateInUpLeft {
   -webkit-animation-name: rotateInUpLeft;
   animation-name: rotateInUpLeft; }
@@ -2669,7 +2738,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 @keyframes rotateInUpRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2683,7 +2751,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
-
 .rotateInUpRight {
   -webkit-animation-name: rotateInUpRight;
   animation-name: rotateInUpRight; }
@@ -2699,7 +2766,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 200deg);
     transform: rotate3d(0, 0, 1, 200deg);
     opacity: 0; } }
-
 @keyframes rotateOut {
   from {
     -webkit-transform-origin: center;
@@ -2711,7 +2777,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 200deg);
     transform: rotate3d(0, 0, 1, 200deg);
     opacity: 0; } }
-
 .rotateOut {
   -webkit-animation-name: rotateOut;
   animation-name: rotateOut; }
@@ -2727,7 +2792,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 45deg);
     transform: rotate3d(0, 0, 1, 45deg);
     opacity: 0; } }
-
 @keyframes rotateOutDownLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2739,7 +2803,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 45deg);
     transform: rotate3d(0, 0, 1, 45deg);
     opacity: 0; } }
-
 .rotateOutDownLeft {
   -webkit-animation-name: rotateOutDownLeft;
   animation-name: rotateOutDownLeft; }
@@ -2755,7 +2818,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
-
 @keyframes rotateOutDownRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2767,7 +2829,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
-
 .rotateOutDownRight {
   -webkit-animation-name: rotateOutDownRight;
   animation-name: rotateOutDownRight; }
@@ -2783,7 +2844,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
-
 @keyframes rotateOutUpLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2795,7 +2855,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
-
 .rotateOutUpLeft {
   -webkit-animation-name: rotateOutUpLeft;
   animation-name: rotateOutUpLeft; }
@@ -2811,7 +2870,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 90deg);
     transform: rotate3d(0, 0, 1, 90deg);
     opacity: 0; } }
-
 @keyframes rotateOutUpRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2823,7 +2881,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 90deg);
     transform: rotate3d(0, 0, 1, 90deg);
     opacity: 0; } }
-
 .rotateOutUpRight {
   -webkit-animation-name: rotateOutUpRight;
   animation-name: rotateOutUpRight; }
@@ -2853,7 +2910,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(0, 700px, 0);
     transform: translate3d(0, 700px, 0);
     opacity: 0; } }
-
 @keyframes hinge {
   0% {
     -webkit-transform-origin: top left;
@@ -2879,7 +2935,6 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(0, 700px, 0);
     transform: translate3d(0, 700px, 0);
     opacity: 0; } }
-
 .hinge {
   -webkit-animation-name: hinge;
   animation-name: hinge; }
@@ -2894,7 +2949,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 @keyframes rollIn {
   from {
     opacity: 0;
@@ -2904,7 +2958,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
-
 .rollIn {
   -webkit-animation-name: rollIn;
   animation-name: rollIn; }
@@ -2917,7 +2970,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg);
     transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg); } }
-
 @keyframes rollOut {
   from {
     opacity: 1; }
@@ -2925,7 +2977,6 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg);
     transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg); } }
-
 .rollOut {
   -webkit-animation-name: rollOut;
   animation-name: rollOut; }
@@ -2937,7 +2988,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   50% {
     opacity: 1; } }
-
 @keyframes zoomIn {
   from {
     opacity: 0;
@@ -2945,7 +2995,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   50% {
     opacity: 1; } }
-
 .zoomIn {
   -webkit-animation-name: zoomIn;
   animation-name: zoomIn; }
@@ -2963,7 +3012,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 @keyframes zoomInDown {
   from {
     opacity: 0;
@@ -2977,7 +3025,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 .zoomInDown {
   -webkit-animation-name: zoomInDown;
   animation-name: zoomInDown; }
@@ -2995,7 +3042,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 @keyframes zoomInLeft {
   from {
     opacity: 0;
@@ -3009,7 +3055,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 .zoomInLeft {
   -webkit-animation-name: zoomInLeft;
   animation-name: zoomInLeft; }
@@ -3027,7 +3072,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 @keyframes zoomInRight {
   from {
     opacity: 0;
@@ -3041,7 +3085,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 .zoomInRight {
   -webkit-animation-name: zoomInRight;
   animation-name: zoomInRight; }
@@ -3059,7 +3102,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 @keyframes zoomInUp {
   from {
     opacity: 0;
@@ -3073,7 +3115,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 .zoomInUp {
   -webkit-animation-name: zoomInUp;
   animation-name: zoomInUp; }
@@ -3087,7 +3128,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   to {
     opacity: 0; } }
-
 @keyframes zoomOut {
   from {
     opacity: 1; }
@@ -3097,7 +3137,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   to {
     opacity: 0; } }
-
 .zoomOut {
   -webkit-animation-name: zoomOut;
   animation-name: zoomOut; }
@@ -3117,7 +3156,6 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 @keyframes zoomOutDown {
   40% {
     opacity: 1;
@@ -3133,7 +3171,6 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 .zoomOutDown {
   -webkit-animation-name: zoomOutDown;
   animation-name: zoomOutDown; }
@@ -3149,7 +3186,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(-2000px, 0, 0);
     -webkit-transform-origin: left center;
     transform-origin: left center; } }
-
 @keyframes zoomOutLeft {
   40% {
     opacity: 1;
@@ -3161,7 +3197,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(-2000px, 0, 0);
     -webkit-transform-origin: left center;
     transform-origin: left center; } }
-
 .zoomOutLeft {
   -webkit-animation-name: zoomOutLeft;
   animation-name: zoomOutLeft; }
@@ -3177,7 +3212,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(2000px, 0, 0);
     -webkit-transform-origin: right center;
     transform-origin: right center; } }
-
 @keyframes zoomOutRight {
   40% {
     opacity: 1;
@@ -3189,7 +3223,6 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(2000px, 0, 0);
     -webkit-transform-origin: right center;
     transform-origin: right center; } }
-
 .zoomOutRight {
   -webkit-animation-name: zoomOutRight;
   animation-name: zoomOutRight; }
@@ -3209,7 +3242,6 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 @keyframes zoomOutUp {
   40% {
     opacity: 1;
@@ -3225,7 +3257,6 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
-
 .zoomOutUp {
   -webkit-animation-name: zoomOutUp;
   animation-name: zoomOutUp; }
@@ -3238,7 +3269,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
-
 @keyframes slideInDown {
   from {
     -webkit-transform: translate3d(0, -100%, 0);
@@ -3247,7 +3277,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
-
 .slideInDown {
   -webkit-animation-name: slideInDown;
   animation-name: slideInDown; }
@@ -3260,7 +3289,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
-
 @keyframes slideInLeft {
   from {
     -webkit-transform: translate3d(-100%, 0, 0);
@@ -3269,7 +3297,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
-
 .slideInLeft {
   -webkit-animation-name: slideInLeft;
   animation-name: slideInLeft; }
@@ -3282,7 +3309,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
-
 @keyframes slideInRight {
   from {
     -webkit-transform: translate3d(100%, 0, 0);
@@ -3291,7 +3317,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
-
 .slideInRight {
   -webkit-animation-name: slideInRight;
   animation-name: slideInRight; }
@@ -3304,7 +3329,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
-
 @keyframes slideInUp {
   from {
     -webkit-transform: translate3d(0, 100%, 0);
@@ -3313,7 +3337,6 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
-
 .slideInUp {
   -webkit-animation-name: slideInUp;
   animation-name: slideInUp; }
@@ -3326,7 +3349,6 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
-
 @keyframes slideOutDown {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3335,7 +3357,6 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
-
 .slideOutDown {
   -webkit-animation-name: slideOutDown;
   animation-name: slideOutDown; }
@@ -3348,7 +3369,6 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
-
 @keyframes slideOutLeft {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3357,7 +3377,6 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
-
 .slideOutLeft {
   -webkit-animation-name: slideOutLeft;
   animation-name: slideOutLeft; }
@@ -3370,7 +3389,6 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
-
 @keyframes slideOutRight {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3379,7 +3397,6 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
-
 .slideOutRight {
   -webkit-animation-name: slideOutRight;
   animation-name: slideOutRight; }
@@ -3392,7 +3409,6 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
-
 @keyframes slideOutUp {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3401,7 +3417,6 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
-
 .slideOutUp {
   -webkit-animation-name: slideOutUp;
   animation-name: slideOutUp; }
@@ -3427,7 +3442,6 @@ h2 {
   text-shadow: none;
   border: none;
   outline: none; }
-
 .a--container input[type="submit"]:active:not(:disabled), div.book-wrapper input[type="submit"]:active:not(:disabled), .a--container input[type="submit"]:focus:not(:disabled), div.book-wrapper input[type="submit"]:focus:not(:disabled), .a--container input[type="button"]:active:not(:disabled), div.book-wrapper input[type="button"]:active:not(:disabled), .a--container input[type="button"]:focus:not(:disabled), div.book-wrapper input[type="button"]:focus:not(:disabled), .a--container button:active:not(:disabled), div.book-wrapper button:active:not(:disabled), .a--container button:focus:not(:disabled), div.book-wrapper button:focus:not(:disabled), .a--container .button:active:not(:disabled), div.book-wrapper .button:active:not(:disabled) {
   box-shadow: none; }
 
@@ -3743,7 +3757,6 @@ span.a--underlined {
   max-height: 0;
   overflow: hidden;
   opacity: 0; }
-
 .a--expanding-section.a--expanded .a--expanding-section__target {
   max-height: 100rem;
   opacity: 1; }
@@ -4088,7 +4101,6 @@ a.new-post-btn {
       font-style: normal;
       font-weight: 400;
       margin-right: 1rem; }
-
 .a--header-design-01 .a--site-menu__container {
   margin: 0;
   font-size: 1.5rem;
@@ -4116,7 +4128,6 @@ a.new-post-btn {
   .a--header-design-01 .a--site-menu__container ul {
     padding: 0;
     margin: 0; }
-
 .a--header-design-01 .a--site-menu__group {
   display: inline-block;
   padding: 0 2rem; }
@@ -4185,7 +4196,6 @@ a.new-post-btn {
         display: none; }
   .a--header-design-01 .a--site-menu__group.a--user-avatar {
     color: rgba(31, 31, 31, 0.6); }
-
 .a--header-design-01 button.a--site-nav__mobile-toggle {
   color: #fff;
   font-size: 2rem;
@@ -4242,7 +4252,6 @@ a.new-post-btn {
     -ms-transform: translateY(1.5rem);
     -o-transform: translateY(1.5rem);
     transform: translateY(1.5rem); }
-
 @-webkit-keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4253,7 +4262,6 @@ a.new-post-btn {
   100% {
     -webkit-transform: scale(0.2);
     opacity: 0.1; } }
-
 @-moz-keyframes togglePulsar {
   0% {
     -moz-transform: scale(0.2);
@@ -4264,7 +4272,6 @@ a.new-post-btn {
   100% {
     -moz-transform: scale(0.2);
     opacity: 0.1; } }
-
 @keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4329,7 +4336,6 @@ a.new-post-btn {
       width: 3.06rem; }
   .a--header-design-01 button.a--site-nav__mobile-toggle.a--toggled .a--toggle-pulsar {
     display: none; }
-
 .a--header-design-01 ul.a--slide-menu__container li {
   display: block; }
   .a--header-design-01 ul.a--slide-menu__container li a {
@@ -4351,7 +4357,6 @@ a.new-post-btn {
     width: 5rem;
     height: 0.2rem;
     background-color: rgba(255, 255, 255, 0.4); }
-
 .a--header-design-01 .a--slide-menu__container, .a--header-design-01 ul.a--slide-menu__container {
   position: absolute;
   z-index: 1001;
@@ -4546,7 +4551,6 @@ a.new-post-btn {
       font-style: normal;
       font-weight: 400;
       margin-right: 1rem; }
-
 .a--header-design-02 .a--site-menu__container {
   margin: 0;
   font-size: 1.5rem;
@@ -4575,7 +4579,6 @@ a.new-post-btn {
   .a--header-design-02 .a--site-menu__container ul {
     padding: 0;
     margin: 0; }
-
 .a--header-design-02 .a--site-menu__group {
   display: inline-block;
   padding: 0 2rem; }
@@ -4643,12 +4646,10 @@ a.new-post-btn {
         display: none; }
   .a--header-design-02 .a--site-menu__group.a--user-avatar {
     color: rgba(31, 31, 31, 0.6); }
-
 .a--header-design-02 .a--slide-menu {
   border-left: 0.2rem solid rgba(31, 31, 31, 0.2);
   margin-left: 2rem;
   padding-left: 4rem !important; }
-
 .a--header-design-02 button.a--site-nav__mobile-toggle {
   color: #fff;
   font-size: 2rem;
@@ -4746,7 +4747,6 @@ a.new-post-btn {
       -ms-transform: translateX(0.5rem) translateY(0.65rem) rotate(-135deg);
       -o-transform: translateX(0.5rem) translateY(0.65rem) rotate(-135deg);
       transform: translateX(0.5rem) translateY(0.65rem) rotate(-135deg); }
-
 @-webkit-keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4757,7 +4757,6 @@ a.new-post-btn {
   100% {
     -webkit-transform: scale(0.2);
     opacity: 0.1; } }
-
 @-moz-keyframes togglePulsar {
   0% {
     -moz-transform: scale(0.2);
@@ -4768,7 +4767,6 @@ a.new-post-btn {
   100% {
     -moz-transform: scale(0.2);
     opacity: 0.1; } }
-
 @keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4813,7 +4811,6 @@ a.new-post-btn {
       width: 3.06rem; }
   .a--header-design-02 button.a--site-nav__mobile-toggle.a--toggled .a--toggle-pulsar {
     display: none; }
-
 .a--header-design-02 ul.a--slide-menu__container li {
   display: block; }
   .a--header-design-02 ul.a--slide-menu__container li a {
@@ -4836,7 +4833,6 @@ a.new-post-btn {
     width: 5rem;
     height: 0.2rem;
     background-color: rgba(255, 255, 255, 0.4); }
-
 .a--header-design-02 .a--slide-menu__container, .a--header-design-02 ul.a--slide-menu__container {
   position: absolute;
   z-index: 1001;
@@ -5164,7 +5160,6 @@ a.new-post-btn {
   @media (max-width: 767px) {
     .a--course-tile-01__wrapper {
       width: 100%; } }
-
 .a--course-tile-01__container {
   border: 0.1rem solid #dedede;
   padding: 0;
@@ -5195,7 +5190,6 @@ a.new-post-btn {
     -webkit-box-shadow: 0 1.9rem 3.8rem rgba(0, 0, 0, 0.3), 0 1.5rem 1.2rem rgba(0, 0, 0, 0.22);
     -moz-box-shadow: 0 1.9rem 3.8rem rgba(0, 0, 0, 0.3), 0 1.5rem 1.2rem rgba(0, 0, 0, 0.22);
     box-shadow: 0 1.9rem 3.8rem rgba(0, 0, 0, 0.3), 0 1.5rem 1.2rem rgba(0, 0, 0, 0.22); }
-
 .a--course-tile-01__image {
   width: 100%;
   height: 18rem;
@@ -5206,7 +5200,6 @@ a.new-post-btn {
   flex-grow: 0;
   -ms-flex-positive: 0;
   border-bottom: 0.4rem solid #3da794; }
-
 .a--course-tile-01__info {
   padding: 3rem 2rem;
   display: -webkit-box;
@@ -5237,7 +5230,6 @@ a.new-post-btn {
   justify-content: space-between;
   -ms-flex-pack: justify;
   background-color: #fff; }
-
 .a--course-tile-01__code, .a--course-tile-01__organization {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5245,7 +5237,6 @@ a.new-post-btn {
   font-size: 1.4rem;
   color: rgba(31, 31, 31, 0.8);
   margin: 0 0 0.5rem; }
-
 .a--course-tile-01__title {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5254,12 +5245,10 @@ a.new-post-btn {
   margin: 0 0 1.5rem;
   color: #3da794;
   display: block; }
-
 .a--course-tile-01__organization {
   border-top: 0.1rem solid rgba(31, 31, 31, 0.1);
   padding-top: 1.5rem;
   display: block; }
-
 .a--course-tile-01__start-date {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5372,7 +5361,6 @@ a.new-post-btn {
   @media (max-width: 767px) {
     .a--course-tile-02__wrapper {
       width: 100%; } }
-
 .a--course-tile-02__container {
   border: 0.1rem solid #dedede;
   padding: 0;
@@ -5389,7 +5377,6 @@ a.new-post-btn {
     -webkit-box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
     -moz-box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
     box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22); }
-
 .a--course-tile-02__image {
   -webkit-flex-shrink: 0;
   -moz-flex-shrink: 0;
@@ -5422,10 +5409,8 @@ a.new-post-btn {
       height: 140px;
       bottom: -28px;
       right: -20px; } }
-
 .a--course-tile-02__info {
   padding: 3rem 2rem; }
-
 .a--course-tile-02__code, .a--course-tile-02__organization {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5433,7 +5418,6 @@ a.new-post-btn {
   font-size: 1.4rem;
   color: rgba(31, 31, 31, 0.8);
   margin: 0 0 0.5rem; }
-
 .a--course-tile-02__title {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5445,7 +5429,6 @@ a.new-post-btn {
   color: #3da794;
   display: block;
   border-bottom: 0.1rem solid rgba(31, 31, 31, 0.2); }
-
 .a--course-tile-02__start-date {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5732,11 +5715,9 @@ a.new-post-btn {
       max-width: 100%; }
     .a--course-listing-01__container.centered .a--course-tile-03 {
       margin: 1rem auto; }
-
 .a--course-listing-01__header {
   margin-bottom: 5rem;
   max-width: 78rem; }
-
 .a--course-listing-01__section-heading {
   font-family: 'Lato', sans-serif;
   font-weight: 300;
@@ -5746,7 +5727,6 @@ a.new-post-btn {
   color: #3da794;
   text-transform: none;
   text-align: inherit; }
-
 .a--course-listing-01__courses {
   display: -webkit-box;
   display: -moz-box;
@@ -6283,7 +6263,6 @@ li.courses-listing-item {
     font-family: "Open Sans", sans-serif;
     font-style: normal;
     font-weight: 700; }
-
 .a--dashboard__content .search-result-list {
   margin: 2rem 0 0;
   padding: 0; }
@@ -6312,7 +6291,6 @@ li.courses-listing-item {
       margin-left: 1rem;
       display: inline-block;
       color: rgba(31, 31, 31, 0.5); }
-
 .a--dashboard__content .search-load-next {
   display: inline-block;
   padding: 1rem 1.5rem;
@@ -6332,7 +6310,6 @@ li.courses-listing-item {
   padding-bottom: 1rem;
   margin: 1rem auto 2rem;
   position: relative; }
-
 .a--courseware-top-nav__mobile-scroll-indicator {
   width: 7rem;
   position: absolute;
@@ -6371,7 +6348,6 @@ li.courses-listing-item {
     -o-justify-content: space-around;
     justify-content: space-around;
     -ms-flex-pack: distribute; }
-
 .a--courseware-top-nav__list-container {
   overflow-y: auto;
   position: relative; }
@@ -6384,7 +6360,6 @@ li.courses-listing-item {
     .a--courseware-top-nav__list-container.a--animated.a--do-animate {
       opacity: 1;
       top: 0; }
-
 .a--courseware-top-nav__list {
   padding: 0;
   margin: 0;
@@ -6404,7 +6379,6 @@ li.courses-listing-item {
   -o-align-items: center;
   align-items: center;
   -ms-flex-align: center; }
-
 .a--courseware-top-nav__item {
   list-style-type: none;
   display: inline-block;
@@ -6443,7 +6417,6 @@ li.courses-listing-item {
       border-radius: 0.5rem; }
       .a--courseware-top-nav__item a.active:hover, .a--courseware-top-nav__item a.active:focus {
         top: 0; }
-
 .a--courseware-top-nav__preview-menu-wrapper {
   padding: 2rem !important;
   background-color: #225c52;
@@ -6458,14 +6431,12 @@ li.courses-listing-item {
 .a--courseware-banner__wrapper {
   padding: 2rem;
   background-color: #dedede; }
-
 .a--courseware-banner__container h2 {
   font-size: 2rem;
   font-family: "Open Sans", sans-serif;
   font-style: normal;
   font-weight: 700;
   margin: 0.5rem 0 1rem; }
-
 .a--courseware-banner__container p {
   margin: 0.5rem 0; }
   .a--courseware-banner__container p a {
@@ -6569,7 +6540,6 @@ li.courses-listing-item {
   font-size: 3.2rem;
   color: #3da794;
   margin: 0 0 2.5rem; }
-
 .a--course-info > ol {
   padding: 0; }
   .a--course-info > ol li {
@@ -6764,7 +6734,6 @@ li.courses-listing-item {
       font-style: italic;
       font-weight: 400;
       color: rgba(31, 31, 31, 0.7); }
-
 .a--course-content__main-content {
   width: 100%;
   min-width: 0;
@@ -7204,10 +7173,8 @@ div.book-wrapper {
   font-weight: 400;
   font-size: 1.6rem;
   line-height: 1.65eem !important; }
-
 .a--course-static-page h1, .a--course-static-page h2, .a--course-static-page h3, .xmodule_display.xmodule_StaticTabModule h1, .xmodule_display.xmodule_StaticTabModule h2, .xmodule_display.xmodule_StaticTabModule h3 {
   text-transform: none; }
-
 .a--course-static-page h1, .xmodule_display.xmodule_StaticTabModule h1 {
   text-transform: none;
   font-family: "Open Sans", sans-serif;
@@ -7216,7 +7183,6 @@ div.book-wrapper {
   font-size: 38.4px;
   color: #3da794;
   letter-spacing: 0; }
-
 .a--course-static-page h2, .xmodule_display.xmodule_StaticTabModule h2 {
   text-transform: none;
   font-family: "Open Sans", sans-serif;
@@ -7225,7 +7191,6 @@ div.book-wrapper {
   font-size: 28.8px;
   color: #3da794;
   letter-spacing: 0; }
-
 .a--course-static-page h3, .xmodule_display.xmodule_StaticTabModule h3 {
   text-transform: none;
   font-family: 'Lato', sans-serif;
@@ -7233,7 +7198,6 @@ div.book-wrapper {
   text-transform: uppercase;
   color: #3da794;
   letter-spacing: 0; }
-
 .a--course-static-page h4, .xmodule_display.xmodule_StaticTabModule h4 {
   text-transform: none;
   font-family: 'Lato', sans-serif;
@@ -7241,7 +7205,6 @@ div.book-wrapper {
   text-transform: uppercase;
   color: rgba(31, 31, 31, 0.75);
   letter-spacing: 0; }
-
 .a--course-static-page ul li, .a--course-static-page ol li, .a--course-static-page .xmodule_display.xmodule_CapaModule div.problem p, .xmodule_display.xmodule_StaticTabModule ul li, .xmodule_display.xmodule_StaticTabModule ol li, .xmodule_display.xmodule_StaticTabModule .xmodule_display.xmodule_CapaModule div.problem p {
   font-size: 16px; }
 
@@ -7375,10 +7338,8 @@ div.book-wrapper {
     font-size: 1.8rem;
     color: #fff;
     margin: -1rem 0 3rem; }
-
 .a--course-about-01__courseware-button-wrapper #register_error {
   display: inline-block; }
-
 .a--course-about-01__social-share {
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
@@ -7431,7 +7392,6 @@ div.book-wrapper {
     opacity: 0.7; }
     .a--course-about-01__social-share a:hover, .a--course-about-01__social-share a:focus {
       opacity: 1; }
-
 .a--course-about-01__courseware-btn {
   background-color: #f6322b;
   border: none;
@@ -7463,7 +7423,6 @@ div.book-wrapper {
     color: #fff; }
   .a--course-about-01__courseware-btn:hover, .a--course-about-01__courseware-btn:focus {
     color: rgba(255, 255, 255, 0.8); }
-
 .a--course-about-01__overview {
   padding: 3rem 0 5rem;
   background-color: transparent;
@@ -7500,7 +7459,6 @@ div.book-wrapper {
     margin-top: 3rem; }
     .a--course-about-01__overview .teacher .teacher-image img {
       float: none; }
-
 .a--course-about-01__info {
   display: block;
   width: 30%;
@@ -7551,7 +7509,6 @@ div.book-wrapper {
       font-style: normal;
       font-weight: 400;
       display: inline-block; }
-
 .a--course-about-01__content {
   padding-bottom: 4rem; }
   @media (min-width: 992px) {
@@ -7929,7 +7886,6 @@ div.book-wrapper {
       opacity: 0.85; }
   .account-settings-sections .section .u-field-message-help {
     color: #1f1f1f; }
-
 .account-settings-sections .section-header {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -7938,7 +7894,6 @@ div.book-wrapper {
   color: rgba(31, 31, 31, 0.7);
   margin-bottom: 10px;
   padding-bottom: 20px; }
-
 .account-settings-sections a, .account-settings-sections a span {
   color: #3da794;
   -webkit-transition: all 0.3s ease-in-out;
@@ -7948,7 +7903,6 @@ div.book-wrapper {
 
 .view-profile .wrapper-profile {
   width: 100%; }
-
 .view-profile .profile-self .wrapper-profile-field-account-privacy {
   background-color: rgba(31, 31, 31, 0.2);
   padding-top: 20px;
@@ -7986,7 +7940,6 @@ div.book-wrapper {
       border-bottom: 1px solid rgba(31, 31, 31, 0.6); }
       .view-profile .profile-self .wrapper-profile-field-account-privacy .u-field-value select:focus {
         outline: none; }
-
 .view-profile .wrapper-profile-sections {
   display: -webkit-box;
   display: -moz-box;
@@ -8004,7 +7957,6 @@ div.book-wrapper {
   flex-wrap: wrap;
   padding: 30px;
   min-width: 0; }
-
 .view-profile .wrapper-profile-section-one {
   display: -webkit-box;
   display: -moz-box;
@@ -8032,7 +7984,6 @@ div.book-wrapper {
       padding: 0 0 20px 0;
       border: none;
       border-bottom: 1px solid rgba(31, 31, 31, 0.2); } }
-
 .view-profile .wrapper-profile-section-two {
   width: 60%;
   padding-left: 20px; }
@@ -8040,13 +7991,11 @@ div.book-wrapper {
     .view-profile .wrapper-profile-section-two {
       width: 100%;
       padding: 20px 0 0 0; } }
-
 .view-profile .profile-image-field {
   -webkit-flex-shrink: 0;
   -moz-flex-shrink: 0;
   flex-shrink: 0;
   -ms-flex-negative: 0; }
-
 .view-profile .profile-section-one-fields {
   -webkit-flex-grow: 1;
   -moz-flex-grow: 1;
@@ -8067,24 +8016,20 @@ div.book-wrapper {
     top: -3px;
     right: 3px;
     color: #3da794 !important; }
-
 .view-profile .profile-section-two-fields .u-field-title {
   width: 80%;
   color: #3da794; }
-
 .view-profile .profile-section-two-fields .editable-toggle {
   padding: 5px;
   -webkit-transition: all 0.2s ease-in-out;
   transition: all 0.2s ease-in-out; }
   .view-profile .profile-section-two-fields .editable-toggle:hover, .view-profile .profile-section-two-fields .editable-toggle:focus {
     background-color: rgba(61, 167, 148, 0.05); }
-
 .view-profile .profile-section-two-fields .message-can-edit {
   position: relative;
   top: -3px;
   right: 3px;
   color: #3da794 !important; }
-
 .view-profile input {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -8242,7 +8187,6 @@ span#djangopid, span#edxver {
     border-bottom: 0.1rem solid rgba(31, 31, 31, 0.2); }
     .a--dashboard-01__notifications__notification:last-child {
       border-bottom: none; }
-
 .a--dashboard-01__main__container {
   display: -webkit-box;
   display: -moz-box;
@@ -8260,7 +8204,6 @@ span#djangopid, span#edxver {
       -moz-flex-wrap: wrap;
       -ms-flex-wrap: wrap;
       flex-wrap: wrap; } }
-
 .a--dashboard-01__main__content {
   -webkit-flex-shrink: 1;
   -moz-flex-shrink: 1;
@@ -8269,10 +8212,8 @@ span#djangopid, span#edxver {
   width: 100%;
   max-width: 98rem;
   margin: 0 auto; }
-
 .a--dashboard-01__main__search-results {
   padding: 0 0 4rem; }
-
 .a--dashboard-01__main__sidebar {
   -webkit-flex-shrink: 0;
   -moz-flex-shrink: 0;
@@ -8288,10 +8229,8 @@ span#djangopid, span#edxver {
       margin-top: 4rem;
       padding-top: 4rem;
       border-top: 0.1rem solid rgba(31, 31, 31, 0.3); } }
-
 .a--dashboard-01__main__courses {
   padding: 0 0 4rem; }
-
 .a--dashboard-01__promote-catalog {
   padding: 3rem 0;
   border-bottom: 0.1rem solid rgba(31, 31, 31, 0.3);
@@ -8630,10 +8569,8 @@ span#djangopid, span#edxver {
     font-size: 1.8rem;
     color: #fff;
     margin: -1rem 0 3rem; }
-
 .a--course-about-palix__courseware-button-wrapper #register_error {
   display: inline-block; }
-
 .a--course-about-palix__social-share {
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
@@ -8687,7 +8624,6 @@ span#djangopid, span#edxver {
     .a--course-about-palix__social-share a:hover, .a--course-about-palix__social-share a:focus {
       color: #fff;
       opacity: 0.7; }
-
 .a--course-about-palix__courseware-btn {
   border: none;
   display: inline-block;
@@ -8721,7 +8657,6 @@ span#djangopid, span#edxver {
   .a--course-about-palix__courseware-btn:hover, .a--course-about-palix__courseware-btn:focus {
     color: #3da794;
     opacity: 0.75; }
-
 .a--course-about-palix__overview {
   padding: 3rem 0 5rem;
   background-color: transparent;
@@ -8777,7 +8712,6 @@ span#djangopid, span#edxver {
     color: #3da794;
     text-transform: uppercase;
     font-size: 2.4rem; }
-
 .a--course-about-palix__info {
   display: block;
   width: 30%;
@@ -8828,7 +8762,6 @@ span#djangopid, span#edxver {
       font-style: normal;
       font-weight: 700;
       display: inline-block; }
-
 .a--course-about-palix__content {
   padding-bottom: 4rem; }
   @media (min-width: 992px) {
@@ -8840,7 +8773,6 @@ span#djangopid, span#edxver {
       display: -moz-flex;
       display: -ms-flexbox;
       display: flex; } }
-
 .a--course-about-palix article.response {
   padding-bottom: 2rem;
   margin-bottom: 2rem;
@@ -8874,7 +8806,7 @@ span#djangopid, span#edxver {
   .a--heading-plus-text-plus-cta.negative .a--cta {
     background-color: #fff;
     color: #3da794; }
-    .a--heading-plus-text-plus-cta.negative .a--cta:hover, .a--heading-plus-text-plus-cta.negative .a--cta:focus  {
+    .a--heading-plus-text-plus-cta.negative .a--cta:hover, .a--heading-plus-text-plus-cta.negative .a--cta:focus  {
       background-color: #fff;
       color: #3da794 !important;
       opacity: 0.7; }
@@ -8892,7 +8824,6 @@ span#djangopid, span#edxver {
   @media (max-width: 767px) {
     .a--course-listing-01__section-heading {
       font-size: 2.4rem; } }
-
 .a--course-listing-01__section-text {
   max-width: 92rem;
   margin: 0 auto;
@@ -8950,7 +8881,6 @@ span#djangopid, span#edxver {
       -moz-flex-wrap: wrap;
       -ms-flex-wrap: wrap;
       flex-wrap: wrap; } }
-
 .palix--index-what-learn__graphic {
   width: 24rem;
   margin-right: 6rem;
@@ -8970,7 +8900,6 @@ span#djangopid, span#edxver {
     display: block;
     width: 100%;
     max-width: 24rem; }
-
 .palix--index-what-learn__content {
   width: 100%;
   -webkit-flex-shrink: 1;
@@ -8981,3 +8910,5 @@ span#djangopid, span#edxver {
   -moz-flex-grow: 1;
   flex-grow: 1;
   -ms-flex-positive: 1; }
+
+/*# sourceMappingURL=main.css.map */

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -185,69 +185,53 @@ th {
     color: #000 !important;
     background: transparent !important;
     box-shadow: none !important; }
-
   a,
   a:visited {
     text-decoration: underline; }
-
   a[href]:after {
     content: " (" attr(href) ")"; }
-
   abbr[title]:after {
     content: " (" attr(title) ")"; }
-
   a[href^="javascript:"]:after,
   a[href^="#"]:after {
     content: ""; }
-
   pre,
   blockquote {
     border: 1px solid #999;
     page-break-inside: avoid; }
-
   thead {
     display: table-header-group; }
-
   tr,
   img {
     page-break-inside: avoid; }
-
   img {
     max-width: 100% !important; }
-
   p,
   h2,
   h3 {
     orphans: 3;
     widows: 3; }
-
   h2,
   h3 {
     page-break-after: avoid; }
-
   select {
     background: #fff !important; }
-
   .navbar {
     display: none; }
-
   .table td,
   .table th {
     background-color: #fff !important; }
-
   .btn > .caret,
   .dropup > .btn > .caret {
     border-top-color: #000 !important; }
-
   .label {
     border: 1px solid #000; }
-
   .table {
     border-collapse: collapse !important; }
-
   .table-bordered th,
   .table-bordered td {
     border: 1px solid #ddd !important; } }
+
 * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -535,471 +519,321 @@ hr {
 @media (min-width: 768px) {
   .col-sm-12, .col-sm-11, .col-sm-10, .col-sm-9, .col-sm-8, .col-sm-7, .col-sm-6, .col-sm-5, .col-sm-4, .col-sm-3, .col-sm-2, .col-sm-1 {
     float: left; }
-
   .col-sm-1 {
     width: 8.33333%; }
-
   .col-sm-2 {
     width: 16.66667%; }
-
   .col-sm-3 {
     width: 25%; }
-
   .col-sm-4 {
     width: 33.33333%; }
-
   .col-sm-5 {
     width: 41.66667%; }
-
   .col-sm-6 {
     width: 50%; }
-
   .col-sm-7 {
     width: 58.33333%; }
-
   .col-sm-8 {
     width: 66.66667%; }
-
   .col-sm-9 {
     width: 75%; }
-
   .col-sm-10 {
     width: 83.33333%; }
-
   .col-sm-11 {
     width: 91.66667%; }
-
   .col-sm-12 {
     width: 100%; }
-
   .col-sm-pull-0 {
     right: 0%; }
-
   .col-sm-pull-1 {
     right: 8.33333%; }
-
   .col-sm-pull-2 {
     right: 16.66667%; }
-
   .col-sm-pull-3 {
     right: 25%; }
-
   .col-sm-pull-4 {
     right: 33.33333%; }
-
   .col-sm-pull-5 {
     right: 41.66667%; }
-
   .col-sm-pull-6 {
     right: 50%; }
-
   .col-sm-pull-7 {
     right: 58.33333%; }
-
   .col-sm-pull-8 {
     right: 66.66667%; }
-
   .col-sm-pull-9 {
     right: 75%; }
-
   .col-sm-pull-10 {
     right: 83.33333%; }
-
   .col-sm-pull-11 {
     right: 91.66667%; }
-
   .col-sm-pull-12 {
     right: 100%; }
-
   .col-sm-push-0 {
     left: 0%; }
-
   .col-sm-push-1 {
     left: 8.33333%; }
-
   .col-sm-push-2 {
     left: 16.66667%; }
-
   .col-sm-push-3 {
     left: 25%; }
-
   .col-sm-push-4 {
     left: 33.33333%; }
-
   .col-sm-push-5 {
     left: 41.66667%; }
-
   .col-sm-push-6 {
     left: 50%; }
-
   .col-sm-push-7 {
     left: 58.33333%; }
-
   .col-sm-push-8 {
     left: 66.66667%; }
-
   .col-sm-push-9 {
     left: 75%; }
-
   .col-sm-push-10 {
     left: 83.33333%; }
-
   .col-sm-push-11 {
     left: 91.66667%; }
-
   .col-sm-push-12 {
     left: 100%; }
-
   .col-sm-offset-0 {
     margin-left: 0%; }
-
   .col-sm-offset-1 {
     margin-left: 8.33333%; }
-
   .col-sm-offset-2 {
     margin-left: 16.66667%; }
-
   .col-sm-offset-3 {
     margin-left: 25%; }
-
   .col-sm-offset-4 {
     margin-left: 33.33333%; }
-
   .col-sm-offset-5 {
     margin-left: 41.66667%; }
-
   .col-sm-offset-6 {
     margin-left: 50%; }
-
   .col-sm-offset-7 {
     margin-left: 58.33333%; }
-
   .col-sm-offset-8 {
     margin-left: 66.66667%; }
-
   .col-sm-offset-9 {
     margin-left: 75%; }
-
   .col-sm-offset-10 {
     margin-left: 83.33333%; }
-
   .col-sm-offset-11 {
     margin-left: 91.66667%; }
-
   .col-sm-offset-12 {
     margin-left: 100%; } }
+
 @media (min-width: 992px) {
   .col-md-12, .col-md-11, .col-md-10, .col-md-9, .col-md-8, .col-md-7, .col-md-6, .col-md-5, .col-md-4, .col-md-3, .col-md-2, .col-md-1 {
     float: left; }
-
   .col-md-1 {
     width: 8.33333%; }
-
   .col-md-2 {
     width: 16.66667%; }
-
   .col-md-3 {
     width: 25%; }
-
   .col-md-4 {
     width: 33.33333%; }
-
   .col-md-5 {
     width: 41.66667%; }
-
   .col-md-6 {
     width: 50%; }
-
   .col-md-7 {
     width: 58.33333%; }
-
   .col-md-8 {
     width: 66.66667%; }
-
   .col-md-9 {
     width: 75%; }
-
   .col-md-10 {
     width: 83.33333%; }
-
   .col-md-11 {
     width: 91.66667%; }
-
   .col-md-12 {
     width: 100%; }
-
   .col-md-pull-0 {
     right: 0%; }
-
   .col-md-pull-1 {
     right: 8.33333%; }
-
   .col-md-pull-2 {
     right: 16.66667%; }
-
   .col-md-pull-3 {
     right: 25%; }
-
   .col-md-pull-4 {
     right: 33.33333%; }
-
   .col-md-pull-5 {
     right: 41.66667%; }
-
   .col-md-pull-6 {
     right: 50%; }
-
   .col-md-pull-7 {
     right: 58.33333%; }
-
   .col-md-pull-8 {
     right: 66.66667%; }
-
   .col-md-pull-9 {
     right: 75%; }
-
   .col-md-pull-10 {
     right: 83.33333%; }
-
   .col-md-pull-11 {
     right: 91.66667%; }
-
   .col-md-pull-12 {
     right: 100%; }
-
   .col-md-push-0 {
     left: 0%; }
-
   .col-md-push-1 {
     left: 8.33333%; }
-
   .col-md-push-2 {
     left: 16.66667%; }
-
   .col-md-push-3 {
     left: 25%; }
-
   .col-md-push-4 {
     left: 33.33333%; }
-
   .col-md-push-5 {
     left: 41.66667%; }
-
   .col-md-push-6 {
     left: 50%; }
-
   .col-md-push-7 {
     left: 58.33333%; }
-
   .col-md-push-8 {
     left: 66.66667%; }
-
   .col-md-push-9 {
     left: 75%; }
-
   .col-md-push-10 {
     left: 83.33333%; }
-
   .col-md-push-11 {
     left: 91.66667%; }
-
   .col-md-push-12 {
     left: 100%; }
-
   .col-md-offset-0 {
     margin-left: 0%; }
-
   .col-md-offset-1 {
     margin-left: 8.33333%; }
-
   .col-md-offset-2 {
     margin-left: 16.66667%; }
-
   .col-md-offset-3 {
     margin-left: 25%; }
-
   .col-md-offset-4 {
     margin-left: 33.33333%; }
-
   .col-md-offset-5 {
     margin-left: 41.66667%; }
-
   .col-md-offset-6 {
     margin-left: 50%; }
-
   .col-md-offset-7 {
     margin-left: 58.33333%; }
-
   .col-md-offset-8 {
     margin-left: 66.66667%; }
-
   .col-md-offset-9 {
     margin-left: 75%; }
-
   .col-md-offset-10 {
     margin-left: 83.33333%; }
-
   .col-md-offset-11 {
     margin-left: 91.66667%; }
-
   .col-md-offset-12 {
     margin-left: 100%; } }
+
 @media (min-width: 1200px) {
   .col-lg-12, .col-lg-11, .col-lg-10, .col-lg-9, .col-lg-8, .col-lg-7, .col-lg-6, .col-lg-5, .col-lg-4, .col-lg-3, .col-lg-2, .col-lg-1 {
     float: left; }
-
   .col-lg-1 {
     width: 8.33333%; }
-
   .col-lg-2 {
     width: 16.66667%; }
-
   .col-lg-3 {
     width: 25%; }
-
   .col-lg-4 {
     width: 33.33333%; }
-
   .col-lg-5 {
     width: 41.66667%; }
-
   .col-lg-6 {
     width: 50%; }
-
   .col-lg-7 {
     width: 58.33333%; }
-
   .col-lg-8 {
     width: 66.66667%; }
-
   .col-lg-9 {
     width: 75%; }
-
   .col-lg-10 {
     width: 83.33333%; }
-
   .col-lg-11 {
     width: 91.66667%; }
-
   .col-lg-12 {
     width: 100%; }
-
   .col-lg-pull-0 {
     right: 0%; }
-
   .col-lg-pull-1 {
     right: 8.33333%; }
-
   .col-lg-pull-2 {
     right: 16.66667%; }
-
   .col-lg-pull-3 {
     right: 25%; }
-
   .col-lg-pull-4 {
     right: 33.33333%; }
-
   .col-lg-pull-5 {
     right: 41.66667%; }
-
   .col-lg-pull-6 {
     right: 50%; }
-
   .col-lg-pull-7 {
     right: 58.33333%; }
-
   .col-lg-pull-8 {
     right: 66.66667%; }
-
   .col-lg-pull-9 {
     right: 75%; }
-
   .col-lg-pull-10 {
     right: 83.33333%; }
-
   .col-lg-pull-11 {
     right: 91.66667%; }
-
   .col-lg-pull-12 {
     right: 100%; }
-
   .col-lg-push-0 {
     left: 0%; }
-
   .col-lg-push-1 {
     left: 8.33333%; }
-
   .col-lg-push-2 {
     left: 16.66667%; }
-
   .col-lg-push-3 {
     left: 25%; }
-
   .col-lg-push-4 {
     left: 33.33333%; }
-
   .col-lg-push-5 {
     left: 41.66667%; }
-
   .col-lg-push-6 {
     left: 50%; }
-
   .col-lg-push-7 {
     left: 58.33333%; }
-
   .col-lg-push-8 {
     left: 66.66667%; }
-
   .col-lg-push-9 {
     left: 75%; }
-
   .col-lg-push-10 {
     left: 83.33333%; }
-
   .col-lg-push-11 {
     left: 91.66667%; }
-
   .col-lg-push-12 {
     left: 100%; }
-
   .col-lg-offset-0 {
     margin-left: 0%; }
-
   .col-lg-offset-1 {
     margin-left: 8.33333%; }
-
   .col-lg-offset-2 {
     margin-left: 16.66667%; }
-
   .col-lg-offset-3 {
     margin-left: 25%; }
-
   .col-lg-offset-4 {
     margin-left: 33.33333%; }
-
   .col-lg-offset-5 {
     margin-left: 41.66667%; }
-
   .col-lg-offset-6 {
     margin-left: 50%; }
-
   .col-lg-offset-7 {
     margin-left: 58.33333%; }
-
   .col-lg-offset-8 {
     margin-left: 66.66667%; }
-
   .col-lg-offset-9 {
     margin-left: 75%; }
-
   .col-lg-offset-10 {
     margin-left: 83.33333%; }
-
   .col-lg-offset-11 {
     margin-left: 91.66667%; }
-
   .col-lg-offset-12 {
     margin-left: 100%; } }
+
 .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
@@ -1094,6 +928,7 @@ hr {
 
 .open > .dropdown-menu {
   display: block; }
+
 .open > a {
   outline: 0; }
 
@@ -1129,6 +964,7 @@ hr {
   border-top: 0;
   border-bottom: 4px solid;
   content: ""; }
+
 .dropup .dropdown-menu,
 .navbar-fixed-bottom .dropdown .dropdown-menu {
   top: auto;
@@ -1142,6 +978,7 @@ hr {
   .navbar-right .dropdown-menu-left {
     left: 0;
     right: auto; } }
+
 .modal-open {
   overflow: hidden; }
 
@@ -1239,16 +1076,14 @@ hr {
   .modal-dialog {
     width: 600px;
     margin: 30px auto; }
-
   .modal-content {
     -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5); }
-
   .modal-sm {
     width: 300px; }
-
   .modal-lg {
     width: 900px; } }
+
 /*!
 Animate.css - http://daneden.me/animate
 Licensed under the MIT license - http://opensource.org/licenses/MIT
@@ -1298,6 +1133,7 @@ Copyright (c) 2015 Daniel Eden
   90% {
     -webkit-transform: translate3d(0, -4px, 0);
     transform: translate3d(0, -4px, 0); } }
+
 @keyframes bounce {
   from, 20%, 53%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1317,6 +1153,7 @@ Copyright (c) 2015 Daniel Eden
   90% {
     -webkit-transform: translate3d(0, -4px, 0);
     transform: translate3d(0, -4px, 0); } }
+
 .bounce {
   -webkit-animation-name: bounce;
   animation-name: bounce;
@@ -1328,11 +1165,13 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1; }
   25%, 75% {
     opacity: 0; } }
+
 @keyframes flash {
   from, 50%, to {
     opacity: 1; }
   25%, 75% {
     opacity: 0; } }
+
 .flash {
   -webkit-animation-name: flash;
   animation-name: flash; }
@@ -1348,6 +1187,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 @keyframes pulse {
   from {
     -webkit-transform: scale3d(1, 1, 1);
@@ -1358,6 +1198,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 .pulse {
   -webkit-animation-name: pulse;
   animation-name: pulse; }
@@ -1384,6 +1225,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 @keyframes rubberBand {
   from {
     -webkit-transform: scale3d(1, 1, 1);
@@ -1406,6 +1248,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 .rubberBand {
   -webkit-animation-name: rubberBand;
   animation-name: rubberBand; }
@@ -1420,6 +1263,7 @@ Copyright (c) 2015 Daniel Eden
   20%, 40%, 60%, 80% {
     -webkit-transform: translate3d(10px, 0, 0);
     transform: translate3d(10px, 0, 0); } }
+
 @keyframes shake {
   from, to {
     -webkit-transform: translate3d(0, 0, 0);
@@ -1430,6 +1274,7 @@ Copyright (c) 2015 Daniel Eden
   20%, 40%, 60%, 80% {
     -webkit-transform: translate3d(10px, 0, 0);
     transform: translate3d(10px, 0, 0); } }
+
 .shake {
   -webkit-animation-name: shake;
   animation-name: shake; }
@@ -1450,6 +1295,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: rotate3d(0, 0, 1, 0deg);
     transform: rotate3d(0, 0, 1, 0deg); } }
+
 @keyframes swing {
   20% {
     -webkit-transform: rotate3d(0, 0, 1, 15deg);
@@ -1466,6 +1312,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: rotate3d(0, 0, 1, 0deg);
     transform: rotate3d(0, 0, 1, 0deg); } }
+
 .swing {
   -webkit-transform-origin: top center;
   transform-origin: top center;
@@ -1488,6 +1335,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 @keyframes tada {
   from {
     -webkit-transform: scale3d(1, 1, 1);
@@ -1504,6 +1352,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 .tada {
   -webkit-animation-name: tada;
   animation-name: tada; }
@@ -1531,6 +1380,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes wobble {
   from {
     -webkit-transform: none;
@@ -1553,6 +1403,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 .wobble {
   -webkit-animation-name: wobble;
   animation-name: wobble; }
@@ -1577,11 +1428,12 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: skewX(-0.78125deg) skewY(-0.78125deg);
     transform: skewX(-0.78125deg) skewY(-0.78125deg); }
   77.7% {
-    -webkit-transform: skewX(0.39063deg) skewY(0.39063deg);
-    transform: skewX(0.39063deg) skewY(0.39063deg); }
+    -webkit-transform: skewX(0.39062deg) skewY(0.39062deg);
+    transform: skewX(0.39062deg) skewY(0.39062deg); }
   88.8% {
     -webkit-transform: skewX(-0.19531deg) skewY(-0.19531deg);
     transform: skewX(-0.19531deg) skewY(-0.19531deg); } }
+
 @keyframes jello {
   from, 11.1%, to {
     -webkit-transform: none;
@@ -1602,11 +1454,12 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: skewX(-0.78125deg) skewY(-0.78125deg);
     transform: skewX(-0.78125deg) skewY(-0.78125deg); }
   77.7% {
-    -webkit-transform: skewX(0.39063deg) skewY(0.39063deg);
-    transform: skewX(0.39063deg) skewY(0.39063deg); }
+    -webkit-transform: skewX(0.39062deg) skewY(0.39062deg);
+    transform: skewX(0.39062deg) skewY(0.39062deg); }
   88.8% {
     -webkit-transform: skewX(-0.19531deg) skewY(-0.19531deg);
     transform: skewX(-0.19531deg) skewY(-0.19531deg); } }
+
 .jello {
   -webkit-animation-name: jello;
   animation-name: jello;
@@ -1638,6 +1491,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 @keyframes bounceIn {
   from, 20%, 40%, 60%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1663,6 +1517,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 .bounceIn {
   -webkit-animation-name: bounceIn;
   animation-name: bounceIn; }
@@ -1688,6 +1543,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes bounceInDown {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1709,6 +1565,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 .bounceInDown {
   -webkit-animation-name: bounceInDown;
   animation-name: bounceInDown; }
@@ -1734,6 +1591,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes bounceInLeft {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1755,6 +1613,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 .bounceInLeft {
   -webkit-animation-name: bounceInLeft;
   animation-name: bounceInLeft; }
@@ -1780,6 +1639,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes bounceInRight {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1801,6 +1661,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 .bounceInRight {
   -webkit-animation-name: bounceInRight;
   animation-name: bounceInRight; }
@@ -1826,6 +1687,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 @keyframes bounceInUp {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1847,6 +1709,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 .bounceInUp {
   -webkit-animation-name: bounceInUp;
   animation-name: bounceInUp; }
@@ -1863,6 +1726,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: scale3d(0.3, 0.3, 0.3);
     transform: scale3d(0.3, 0.3, 0.3); } }
+
 @keyframes bounceOut {
   20% {
     -webkit-transform: scale3d(0.9, 0.9, 0.9);
@@ -1875,6 +1739,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: scale3d(0.3, 0.3, 0.3);
     transform: scale3d(0.3, 0.3, 0.3); } }
+
 .bounceOut {
   -webkit-animation-name: bounceOut;
   animation-name: bounceOut; }
@@ -1891,6 +1756,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
+
 @keyframes bounceOutDown {
   20% {
     -webkit-transform: translate3d(0, 10px, 0);
@@ -1903,6 +1769,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
+
 .bounceOutDown {
   -webkit-animation-name: bounceOutDown;
   animation-name: bounceOutDown; }
@@ -1916,6 +1783,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
+
 @keyframes bounceOutLeft {
   20% {
     opacity: 1;
@@ -1925,6 +1793,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
+
 .bounceOutLeft {
   -webkit-animation-name: bounceOutLeft;
   animation-name: bounceOutLeft; }
@@ -1938,6 +1807,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
+
 @keyframes bounceOutRight {
   20% {
     opacity: 1;
@@ -1947,6 +1817,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
+
 .bounceOutRight {
   -webkit-animation-name: bounceOutRight;
   animation-name: bounceOutRight; }
@@ -1963,6 +1834,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
+
 @keyframes bounceOutUp {
   20% {
     -webkit-transform: translate3d(0, -10px, 0);
@@ -1975,6 +1847,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
+
 .bounceOutUp {
   -webkit-animation-name: bounceOutUp;
   animation-name: bounceOutUp; }
@@ -1984,11 +1857,13 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0; }
   to {
     opacity: 1; } }
+
 @keyframes fadeIn {
   from {
     opacity: 0; }
   to {
     opacity: 1; } }
+
 .fadeIn {
   -webkit-animation-name: fadeIn;
   animation-name: fadeIn; }
@@ -2002,6 +1877,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInDown {
   from {
     opacity: 0;
@@ -2011,6 +1887,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInDown {
   -webkit-animation-name: fadeInDown;
   animation-name: fadeInDown; }
@@ -2024,6 +1901,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInDownBig {
   from {
     opacity: 0;
@@ -2033,6 +1911,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInDownBig {
   -webkit-animation-name: fadeInDownBig;
   animation-name: fadeInDownBig; }
@@ -2046,6 +1925,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInLeft {
   from {
     opacity: 0;
@@ -2055,6 +1935,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInLeft {
   -webkit-animation-name: fadeInLeft;
   animation-name: fadeInLeft; }
@@ -2068,6 +1949,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInLeftBig {
   from {
     opacity: 0;
@@ -2077,6 +1959,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInLeftBig {
   -webkit-animation-name: fadeInLeftBig;
   animation-name: fadeInLeftBig; }
@@ -2090,6 +1973,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInRight {
   from {
     opacity: 0;
@@ -2099,6 +1983,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInRight {
   -webkit-animation-name: fadeInRight;
   animation-name: fadeInRight; }
@@ -2112,6 +1997,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInRightBig {
   from {
     opacity: 0;
@@ -2121,6 +2007,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInRightBig {
   -webkit-animation-name: fadeInRightBig;
   animation-name: fadeInRightBig; }
@@ -2134,6 +2021,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInUp {
   from {
     opacity: 0;
@@ -2143,6 +2031,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInUp {
   -webkit-animation-name: fadeInUp;
   animation-name: fadeInUp; }
@@ -2156,6 +2045,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInUpBig {
   from {
     opacity: 0;
@@ -2165,6 +2055,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInUpBig {
   -webkit-animation-name: fadeInUpBig;
   animation-name: fadeInUpBig; }
@@ -2174,11 +2065,13 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1; }
   to {
     opacity: 0; } }
+
 @keyframes fadeOut {
   from {
     opacity: 1; }
   to {
     opacity: 0; } }
+
 .fadeOut {
   -webkit-animation-name: fadeOut;
   animation-name: fadeOut; }
@@ -2190,6 +2083,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
+
 @keyframes fadeOutDown {
   from {
     opacity: 1; }
@@ -2197,6 +2091,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
+
 .fadeOutDown {
   -webkit-animation-name: fadeOutDown;
   animation-name: fadeOutDown; }
@@ -2208,6 +2103,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
+
 @keyframes fadeOutDownBig {
   from {
     opacity: 1; }
@@ -2215,6 +2111,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
+
 .fadeOutDownBig {
   -webkit-animation-name: fadeOutDownBig;
   animation-name: fadeOutDownBig; }
@@ -2226,6 +2123,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
+
 @keyframes fadeOutLeft {
   from {
     opacity: 1; }
@@ -2233,6 +2131,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
+
 .fadeOutLeft {
   -webkit-animation-name: fadeOutLeft;
   animation-name: fadeOutLeft; }
@@ -2244,6 +2143,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
+
 @keyframes fadeOutLeftBig {
   from {
     opacity: 1; }
@@ -2251,6 +2151,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
+
 .fadeOutLeftBig {
   -webkit-animation-name: fadeOutLeftBig;
   animation-name: fadeOutLeftBig; }
@@ -2262,6 +2163,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
+
 @keyframes fadeOutRight {
   from {
     opacity: 1; }
@@ -2269,6 +2171,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
+
 .fadeOutRight {
   -webkit-animation-name: fadeOutRight;
   animation-name: fadeOutRight; }
@@ -2280,6 +2183,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
+
 @keyframes fadeOutRightBig {
   from {
     opacity: 1; }
@@ -2287,6 +2191,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
+
 .fadeOutRightBig {
   -webkit-animation-name: fadeOutRightBig;
   animation-name: fadeOutRightBig; }
@@ -2298,6 +2203,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
+
 @keyframes fadeOutUp {
   from {
     opacity: 1; }
@@ -2305,6 +2211,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
+
 .fadeOutUp {
   -webkit-animation-name: fadeOutUp;
   animation-name: fadeOutUp; }
@@ -2316,6 +2223,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
+
 @keyframes fadeOutUpBig {
   from {
     opacity: 1; }
@@ -2323,6 +2231,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
+
 .fadeOutUpBig {
   -webkit-animation-name: fadeOutUpBig;
   animation-name: fadeOutUpBig; }
@@ -2353,6 +2262,7 @@ Copyright (c) 2015 Daniel Eden
     transform: perspective(400px);
     -webkit-animation-timing-function: ease-in;
     animation-timing-function: ease-in; } }
+
 @keyframes flip {
   from {
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, -360deg);
@@ -2379,6 +2289,7 @@ Copyright (c) 2015 Daniel Eden
     transform: perspective(400px);
     -webkit-animation-timing-function: ease-in;
     animation-timing-function: ease-in; } }
+
 .animated.flip {
   -webkit-backface-visibility: visible;
   backface-visibility: visible;
@@ -2407,6 +2318,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
+
 @keyframes flipInX {
   from {
     -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
@@ -2429,6 +2341,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
+
 .flipInX {
   -webkit-backface-visibility: visible !important;
   backface-visibility: visible !important;
@@ -2457,6 +2370,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
+
 @keyframes flipInY {
   from {
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
@@ -2479,6 +2393,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
+
 .flipInY {
   -webkit-backface-visibility: visible !important;
   backface-visibility: visible !important;
@@ -2497,6 +2412,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     opacity: 0; } }
+
 @keyframes flipOutX {
   from {
     -webkit-transform: perspective(400px);
@@ -2509,6 +2425,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     opacity: 0; } }
+
 .flipOutX {
   -webkit-animation-name: flipOutX;
   animation-name: flipOutX;
@@ -2527,6 +2444,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     opacity: 0; } }
+
 @keyframes flipOutY {
   from {
     -webkit-transform: perspective(400px);
@@ -2539,6 +2457,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     opacity: 0; } }
+
 .flipOutY {
   -webkit-backface-visibility: visible !important;
   backface-visibility: visible !important;
@@ -2562,6 +2481,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes lightSpeedIn {
   from {
     -webkit-transform: translate3d(100%, 0, 0) skewX(-30deg);
@@ -2579,6 +2499,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .lightSpeedIn {
   -webkit-animation-name: lightSpeedIn;
   animation-name: lightSpeedIn;
@@ -2592,6 +2513,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(100%, 0, 0) skewX(30deg);
     transform: translate3d(100%, 0, 0) skewX(30deg);
     opacity: 0; } }
+
 @keyframes lightSpeedOut {
   from {
     opacity: 1; }
@@ -2599,6 +2521,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(100%, 0, 0) skewX(30deg);
     transform: translate3d(100%, 0, 0) skewX(30deg);
     opacity: 0; } }
+
 .lightSpeedOut {
   -webkit-animation-name: lightSpeedOut;
   animation-name: lightSpeedOut;
@@ -2618,6 +2541,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes rotateIn {
   from {
     -webkit-transform-origin: center;
@@ -2631,6 +2555,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .rotateIn {
   -webkit-animation-name: rotateIn;
   animation-name: rotateIn; }
@@ -2648,6 +2573,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes rotateInDownLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2661,6 +2587,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .rotateInDownLeft {
   -webkit-animation-name: rotateInDownLeft;
   animation-name: rotateInDownLeft; }
@@ -2678,6 +2605,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes rotateInDownRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2691,6 +2619,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .rotateInDownRight {
   -webkit-animation-name: rotateInDownRight;
   animation-name: rotateInDownRight; }
@@ -2708,6 +2637,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes rotateInUpLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2721,6 +2651,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .rotateInUpLeft {
   -webkit-animation-name: rotateInUpLeft;
   animation-name: rotateInUpLeft; }
@@ -2738,6 +2669,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes rotateInUpRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2751,6 +2683,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .rotateInUpRight {
   -webkit-animation-name: rotateInUpRight;
   animation-name: rotateInUpRight; }
@@ -2766,6 +2699,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 200deg);
     transform: rotate3d(0, 0, 1, 200deg);
     opacity: 0; } }
+
 @keyframes rotateOut {
   from {
     -webkit-transform-origin: center;
@@ -2777,6 +2711,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 200deg);
     transform: rotate3d(0, 0, 1, 200deg);
     opacity: 0; } }
+
 .rotateOut {
   -webkit-animation-name: rotateOut;
   animation-name: rotateOut; }
@@ -2792,6 +2727,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 45deg);
     transform: rotate3d(0, 0, 1, 45deg);
     opacity: 0; } }
+
 @keyframes rotateOutDownLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2803,6 +2739,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 45deg);
     transform: rotate3d(0, 0, 1, 45deg);
     opacity: 0; } }
+
 .rotateOutDownLeft {
   -webkit-animation-name: rotateOutDownLeft;
   animation-name: rotateOutDownLeft; }
@@ -2818,6 +2755,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
+
 @keyframes rotateOutDownRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2829,6 +2767,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
+
 .rotateOutDownRight {
   -webkit-animation-name: rotateOutDownRight;
   animation-name: rotateOutDownRight; }
@@ -2844,6 +2783,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
+
 @keyframes rotateOutUpLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2855,6 +2795,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
+
 .rotateOutUpLeft {
   -webkit-animation-name: rotateOutUpLeft;
   animation-name: rotateOutUpLeft; }
@@ -2870,6 +2811,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 90deg);
     transform: rotate3d(0, 0, 1, 90deg);
     opacity: 0; } }
+
 @keyframes rotateOutUpRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2881,6 +2823,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 90deg);
     transform: rotate3d(0, 0, 1, 90deg);
     opacity: 0; } }
+
 .rotateOutUpRight {
   -webkit-animation-name: rotateOutUpRight;
   animation-name: rotateOutUpRight; }
@@ -2910,6 +2853,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(0, 700px, 0);
     transform: translate3d(0, 700px, 0);
     opacity: 0; } }
+
 @keyframes hinge {
   0% {
     -webkit-transform-origin: top left;
@@ -2935,6 +2879,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(0, 700px, 0);
     transform: translate3d(0, 700px, 0);
     opacity: 0; } }
+
 .hinge {
   -webkit-animation-name: hinge;
   animation-name: hinge; }
@@ -2949,6 +2894,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes rollIn {
   from {
     opacity: 0;
@@ -2958,6 +2904,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .rollIn {
   -webkit-animation-name: rollIn;
   animation-name: rollIn; }
@@ -2970,6 +2917,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg);
     transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg); } }
+
 @keyframes rollOut {
   from {
     opacity: 1; }
@@ -2977,6 +2925,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg);
     transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg); } }
+
 .rollOut {
   -webkit-animation-name: rollOut;
   animation-name: rollOut; }
@@ -2988,6 +2937,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   50% {
     opacity: 1; } }
+
 @keyframes zoomIn {
   from {
     opacity: 0;
@@ -2995,6 +2945,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   50% {
     opacity: 1; } }
+
 .zoomIn {
   -webkit-animation-name: zoomIn;
   animation-name: zoomIn; }
@@ -3012,6 +2963,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomInDown {
   from {
     opacity: 0;
@@ -3025,6 +2977,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomInDown {
   -webkit-animation-name: zoomInDown;
   animation-name: zoomInDown; }
@@ -3042,6 +2995,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomInLeft {
   from {
     opacity: 0;
@@ -3055,6 +3009,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomInLeft {
   -webkit-animation-name: zoomInLeft;
   animation-name: zoomInLeft; }
@@ -3072,6 +3027,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomInRight {
   from {
     opacity: 0;
@@ -3085,6 +3041,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomInRight {
   -webkit-animation-name: zoomInRight;
   animation-name: zoomInRight; }
@@ -3102,6 +3059,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomInUp {
   from {
     opacity: 0;
@@ -3115,6 +3073,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomInUp {
   -webkit-animation-name: zoomInUp;
   animation-name: zoomInUp; }
@@ -3128,6 +3087,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   to {
     opacity: 0; } }
+
 @keyframes zoomOut {
   from {
     opacity: 1; }
@@ -3137,6 +3097,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   to {
     opacity: 0; } }
+
 .zoomOut {
   -webkit-animation-name: zoomOut;
   animation-name: zoomOut; }
@@ -3156,6 +3117,7 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomOutDown {
   40% {
     opacity: 1;
@@ -3171,6 +3133,7 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomOutDown {
   -webkit-animation-name: zoomOutDown;
   animation-name: zoomOutDown; }
@@ -3186,6 +3149,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(-2000px, 0, 0);
     -webkit-transform-origin: left center;
     transform-origin: left center; } }
+
 @keyframes zoomOutLeft {
   40% {
     opacity: 1;
@@ -3197,6 +3161,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(-2000px, 0, 0);
     -webkit-transform-origin: left center;
     transform-origin: left center; } }
+
 .zoomOutLeft {
   -webkit-animation-name: zoomOutLeft;
   animation-name: zoomOutLeft; }
@@ -3212,6 +3177,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(2000px, 0, 0);
     -webkit-transform-origin: right center;
     transform-origin: right center; } }
+
 @keyframes zoomOutRight {
   40% {
     opacity: 1;
@@ -3223,6 +3189,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(2000px, 0, 0);
     -webkit-transform-origin: right center;
     transform-origin: right center; } }
+
 .zoomOutRight {
   -webkit-animation-name: zoomOutRight;
   animation-name: zoomOutRight; }
@@ -3242,6 +3209,7 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomOutUp {
   40% {
     opacity: 1;
@@ -3257,6 +3225,7 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomOutUp {
   -webkit-animation-name: zoomOutUp;
   animation-name: zoomOutUp; }
@@ -3269,6 +3238,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 @keyframes slideInDown {
   from {
     -webkit-transform: translate3d(0, -100%, 0);
@@ -3277,6 +3247,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 .slideInDown {
   -webkit-animation-name: slideInDown;
   animation-name: slideInDown; }
@@ -3289,6 +3260,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 @keyframes slideInLeft {
   from {
     -webkit-transform: translate3d(-100%, 0, 0);
@@ -3297,6 +3269,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 .slideInLeft {
   -webkit-animation-name: slideInLeft;
   animation-name: slideInLeft; }
@@ -3309,6 +3282,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 @keyframes slideInRight {
   from {
     -webkit-transform: translate3d(100%, 0, 0);
@@ -3317,6 +3291,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 .slideInRight {
   -webkit-animation-name: slideInRight;
   animation-name: slideInRight; }
@@ -3329,6 +3304,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 @keyframes slideInUp {
   from {
     -webkit-transform: translate3d(0, 100%, 0);
@@ -3337,6 +3313,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 .slideInUp {
   -webkit-animation-name: slideInUp;
   animation-name: slideInUp; }
@@ -3349,6 +3326,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
+
 @keyframes slideOutDown {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3357,6 +3335,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
+
 .slideOutDown {
   -webkit-animation-name: slideOutDown;
   animation-name: slideOutDown; }
@@ -3369,6 +3348,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
+
 @keyframes slideOutLeft {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3377,6 +3357,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
+
 .slideOutLeft {
   -webkit-animation-name: slideOutLeft;
   animation-name: slideOutLeft; }
@@ -3389,6 +3370,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
+
 @keyframes slideOutRight {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3397,6 +3379,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
+
 .slideOutRight {
   -webkit-animation-name: slideOutRight;
   animation-name: slideOutRight; }
@@ -3409,6 +3392,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
+
 @keyframes slideOutUp {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3417,6 +3401,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
+
 .slideOutUp {
   -webkit-animation-name: slideOutUp;
   animation-name: slideOutUp; }
@@ -3442,6 +3427,7 @@ h2 {
   text-shadow: none;
   border: none;
   outline: none; }
+
 .a--container input[type="submit"]:active:not(:disabled), div.book-wrapper input[type="submit"]:active:not(:disabled), .a--container input[type="submit"]:focus:not(:disabled), div.book-wrapper input[type="submit"]:focus:not(:disabled), .a--container input[type="button"]:active:not(:disabled), div.book-wrapper input[type="button"]:active:not(:disabled), .a--container input[type="button"]:focus:not(:disabled), div.book-wrapper input[type="button"]:focus:not(:disabled), .a--container button:active:not(:disabled), div.book-wrapper button:active:not(:disabled), .a--container button:focus:not(:disabled), div.book-wrapper button:focus:not(:disabled), .a--container .button:active:not(:disabled), div.book-wrapper .button:active:not(:disabled) {
   box-shadow: none; }
 
@@ -3757,6 +3743,7 @@ span.a--underlined {
   max-height: 0;
   overflow: hidden;
   opacity: 0; }
+
 .a--expanding-section.a--expanded .a--expanding-section__target {
   max-height: 100rem;
   opacity: 1; }
@@ -4101,6 +4088,7 @@ a.new-post-btn {
       font-style: normal;
       font-weight: 400;
       margin-right: 1rem; }
+
 .a--header-design-01 .a--site-menu__container {
   margin: 0;
   font-size: 1.5rem;
@@ -4128,6 +4116,7 @@ a.new-post-btn {
   .a--header-design-01 .a--site-menu__container ul {
     padding: 0;
     margin: 0; }
+
 .a--header-design-01 .a--site-menu__group {
   display: inline-block;
   padding: 0 2rem; }
@@ -4196,6 +4185,7 @@ a.new-post-btn {
         display: none; }
   .a--header-design-01 .a--site-menu__group.a--user-avatar {
     color: rgba(31, 31, 31, 0.6); }
+
 .a--header-design-01 button.a--site-nav__mobile-toggle {
   color: #fff;
   font-size: 2rem;
@@ -4252,6 +4242,7 @@ a.new-post-btn {
     -ms-transform: translateY(1.5rem);
     -o-transform: translateY(1.5rem);
     transform: translateY(1.5rem); }
+
 @-webkit-keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4262,6 +4253,7 @@ a.new-post-btn {
   100% {
     -webkit-transform: scale(0.2);
     opacity: 0.1; } }
+
 @-moz-keyframes togglePulsar {
   0% {
     -moz-transform: scale(0.2);
@@ -4272,6 +4264,7 @@ a.new-post-btn {
   100% {
     -moz-transform: scale(0.2);
     opacity: 0.1; } }
+
 @keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4336,6 +4329,7 @@ a.new-post-btn {
       width: 3.06rem; }
   .a--header-design-01 button.a--site-nav__mobile-toggle.a--toggled .a--toggle-pulsar {
     display: none; }
+
 .a--header-design-01 ul.a--slide-menu__container li {
   display: block; }
   .a--header-design-01 ul.a--slide-menu__container li a {
@@ -4357,6 +4351,7 @@ a.new-post-btn {
     width: 5rem;
     height: 0.2rem;
     background-color: rgba(255, 255, 255, 0.4); }
+
 .a--header-design-01 .a--slide-menu__container, .a--header-design-01 ul.a--slide-menu__container {
   position: absolute;
   z-index: 1001;
@@ -4551,6 +4546,7 @@ a.new-post-btn {
       font-style: normal;
       font-weight: 400;
       margin-right: 1rem; }
+
 .a--header-design-02 .a--site-menu__container {
   margin: 0;
   font-size: 1.5rem;
@@ -4579,6 +4575,7 @@ a.new-post-btn {
   .a--header-design-02 .a--site-menu__container ul {
     padding: 0;
     margin: 0; }
+
 .a--header-design-02 .a--site-menu__group {
   display: inline-block;
   padding: 0 2rem; }
@@ -4646,10 +4643,12 @@ a.new-post-btn {
         display: none; }
   .a--header-design-02 .a--site-menu__group.a--user-avatar {
     color: rgba(31, 31, 31, 0.6); }
+
 .a--header-design-02 .a--slide-menu {
   border-left: 0.2rem solid rgba(31, 31, 31, 0.2);
   margin-left: 2rem;
   padding-left: 4rem !important; }
+
 .a--header-design-02 button.a--site-nav__mobile-toggle {
   color: #fff;
   font-size: 2rem;
@@ -4747,6 +4746,7 @@ a.new-post-btn {
       -ms-transform: translateX(0.5rem) translateY(0.65rem) rotate(-135deg);
       -o-transform: translateX(0.5rem) translateY(0.65rem) rotate(-135deg);
       transform: translateX(0.5rem) translateY(0.65rem) rotate(-135deg); }
+
 @-webkit-keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4757,6 +4757,7 @@ a.new-post-btn {
   100% {
     -webkit-transform: scale(0.2);
     opacity: 0.1; } }
+
 @-moz-keyframes togglePulsar {
   0% {
     -moz-transform: scale(0.2);
@@ -4767,6 +4768,7 @@ a.new-post-btn {
   100% {
     -moz-transform: scale(0.2);
     opacity: 0.1; } }
+
 @keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4811,6 +4813,7 @@ a.new-post-btn {
       width: 3.06rem; }
   .a--header-design-02 button.a--site-nav__mobile-toggle.a--toggled .a--toggle-pulsar {
     display: none; }
+
 .a--header-design-02 ul.a--slide-menu__container li {
   display: block; }
   .a--header-design-02 ul.a--slide-menu__container li a {
@@ -4833,6 +4836,7 @@ a.new-post-btn {
     width: 5rem;
     height: 0.2rem;
     background-color: rgba(255, 255, 255, 0.4); }
+
 .a--header-design-02 .a--slide-menu__container, .a--header-design-02 ul.a--slide-menu__container {
   position: absolute;
   z-index: 1001;
@@ -5160,6 +5164,7 @@ a.new-post-btn {
   @media (max-width: 767px) {
     .a--course-tile-01__wrapper {
       width: 100%; } }
+
 .a--course-tile-01__container {
   border: 0.1rem solid #dedede;
   padding: 0;
@@ -5190,6 +5195,7 @@ a.new-post-btn {
     -webkit-box-shadow: 0 1.9rem 3.8rem rgba(0, 0, 0, 0.3), 0 1.5rem 1.2rem rgba(0, 0, 0, 0.22);
     -moz-box-shadow: 0 1.9rem 3.8rem rgba(0, 0, 0, 0.3), 0 1.5rem 1.2rem rgba(0, 0, 0, 0.22);
     box-shadow: 0 1.9rem 3.8rem rgba(0, 0, 0, 0.3), 0 1.5rem 1.2rem rgba(0, 0, 0, 0.22); }
+
 .a--course-tile-01__image {
   width: 100%;
   height: 18rem;
@@ -5200,6 +5206,7 @@ a.new-post-btn {
   flex-grow: 0;
   -ms-flex-positive: 0;
   border-bottom: 0.4rem solid #3da794; }
+
 .a--course-tile-01__info {
   padding: 3rem 2rem;
   display: -webkit-box;
@@ -5230,6 +5237,7 @@ a.new-post-btn {
   justify-content: space-between;
   -ms-flex-pack: justify;
   background-color: #fff; }
+
 .a--course-tile-01__code, .a--course-tile-01__organization {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5237,6 +5245,7 @@ a.new-post-btn {
   font-size: 1.4rem;
   color: rgba(31, 31, 31, 0.8);
   margin: 0 0 0.5rem; }
+
 .a--course-tile-01__title {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5245,10 +5254,12 @@ a.new-post-btn {
   margin: 0 0 1.5rem;
   color: #3da794;
   display: block; }
+
 .a--course-tile-01__organization {
   border-top: 0.1rem solid rgba(31, 31, 31, 0.1);
   padding-top: 1.5rem;
   display: block; }
+
 .a--course-tile-01__start-date {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5361,6 +5372,7 @@ a.new-post-btn {
   @media (max-width: 767px) {
     .a--course-tile-02__wrapper {
       width: 100%; } }
+
 .a--course-tile-02__container {
   border: 0.1rem solid #dedede;
   padding: 0;
@@ -5377,6 +5389,7 @@ a.new-post-btn {
     -webkit-box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
     -moz-box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
     box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22); }
+
 .a--course-tile-02__image {
   -webkit-flex-shrink: 0;
   -moz-flex-shrink: 0;
@@ -5409,8 +5422,10 @@ a.new-post-btn {
       height: 140px;
       bottom: -28px;
       right: -20px; } }
+
 .a--course-tile-02__info {
   padding: 3rem 2rem; }
+
 .a--course-tile-02__code, .a--course-tile-02__organization {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5418,6 +5433,7 @@ a.new-post-btn {
   font-size: 1.4rem;
   color: rgba(31, 31, 31, 0.8);
   margin: 0 0 0.5rem; }
+
 .a--course-tile-02__title {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5429,6 +5445,7 @@ a.new-post-btn {
   color: #3da794;
   display: block;
   border-bottom: 0.1rem solid rgba(31, 31, 31, 0.2); }
+
 .a--course-tile-02__start-date {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5715,9 +5732,11 @@ a.new-post-btn {
       max-width: 100%; }
     .a--course-listing-01__container.centered .a--course-tile-03 {
       margin: 1rem auto; }
+
 .a--course-listing-01__header {
   margin-bottom: 5rem;
   max-width: 78rem; }
+
 .a--course-listing-01__section-heading {
   font-family: 'Lato', sans-serif;
   font-weight: 300;
@@ -5727,6 +5746,7 @@ a.new-post-btn {
   color: #3da794;
   text-transform: none;
   text-align: inherit; }
+
 .a--course-listing-01__courses {
   display: -webkit-box;
   display: -moz-box;
@@ -6263,6 +6283,7 @@ li.courses-listing-item {
     font-family: "Open Sans", sans-serif;
     font-style: normal;
     font-weight: 700; }
+
 .a--dashboard__content .search-result-list {
   margin: 2rem 0 0;
   padding: 0; }
@@ -6291,6 +6312,7 @@ li.courses-listing-item {
       margin-left: 1rem;
       display: inline-block;
       color: rgba(31, 31, 31, 0.5); }
+
 .a--dashboard__content .search-load-next {
   display: inline-block;
   padding: 1rem 1.5rem;
@@ -6310,6 +6332,7 @@ li.courses-listing-item {
   padding-bottom: 1rem;
   margin: 1rem auto 2rem;
   position: relative; }
+
 .a--courseware-top-nav__mobile-scroll-indicator {
   width: 7rem;
   position: absolute;
@@ -6348,6 +6371,7 @@ li.courses-listing-item {
     -o-justify-content: space-around;
     justify-content: space-around;
     -ms-flex-pack: distribute; }
+
 .a--courseware-top-nav__list-container {
   overflow-y: auto;
   position: relative; }
@@ -6360,6 +6384,7 @@ li.courses-listing-item {
     .a--courseware-top-nav__list-container.a--animated.a--do-animate {
       opacity: 1;
       top: 0; }
+
 .a--courseware-top-nav__list {
   padding: 0;
   margin: 0;
@@ -6379,6 +6404,7 @@ li.courses-listing-item {
   -o-align-items: center;
   align-items: center;
   -ms-flex-align: center; }
+
 .a--courseware-top-nav__item {
   list-style-type: none;
   display: inline-block;
@@ -6417,6 +6443,7 @@ li.courses-listing-item {
       border-radius: 0.5rem; }
       .a--courseware-top-nav__item a.active:hover, .a--courseware-top-nav__item a.active:focus {
         top: 0; }
+
 .a--courseware-top-nav__preview-menu-wrapper {
   padding: 2rem !important;
   background-color: #225c52;
@@ -6431,12 +6458,14 @@ li.courses-listing-item {
 .a--courseware-banner__wrapper {
   padding: 2rem;
   background-color: #dedede; }
+
 .a--courseware-banner__container h2 {
   font-size: 2rem;
   font-family: "Open Sans", sans-serif;
   font-style: normal;
   font-weight: 700;
   margin: 0.5rem 0 1rem; }
+
 .a--courseware-banner__container p {
   margin: 0.5rem 0; }
   .a--courseware-banner__container p a {
@@ -6540,6 +6569,7 @@ li.courses-listing-item {
   font-size: 3.2rem;
   color: #3da794;
   margin: 0 0 2.5rem; }
+
 .a--course-info > ol {
   padding: 0; }
   .a--course-info > ol li {
@@ -6734,6 +6764,7 @@ li.courses-listing-item {
       font-style: italic;
       font-weight: 400;
       color: rgba(31, 31, 31, 0.7); }
+
 .a--course-content__main-content {
   width: 100%;
   min-width: 0;
@@ -7173,8 +7204,10 @@ div.book-wrapper {
   font-weight: 400;
   font-size: 1.6rem;
   line-height: 1.65eem !important; }
+
 .a--course-static-page h1, .a--course-static-page h2, .a--course-static-page h3, .xmodule_display.xmodule_StaticTabModule h1, .xmodule_display.xmodule_StaticTabModule h2, .xmodule_display.xmodule_StaticTabModule h3 {
   text-transform: none; }
+
 .a--course-static-page h1, .xmodule_display.xmodule_StaticTabModule h1 {
   text-transform: none;
   font-family: "Open Sans", sans-serif;
@@ -7183,6 +7216,7 @@ div.book-wrapper {
   font-size: 38.4px;
   color: #3da794;
   letter-spacing: 0; }
+
 .a--course-static-page h2, .xmodule_display.xmodule_StaticTabModule h2 {
   text-transform: none;
   font-family: "Open Sans", sans-serif;
@@ -7191,6 +7225,7 @@ div.book-wrapper {
   font-size: 28.8px;
   color: #3da794;
   letter-spacing: 0; }
+
 .a--course-static-page h3, .xmodule_display.xmodule_StaticTabModule h3 {
   text-transform: none;
   font-family: 'Lato', sans-serif;
@@ -7198,6 +7233,7 @@ div.book-wrapper {
   text-transform: uppercase;
   color: #3da794;
   letter-spacing: 0; }
+
 .a--course-static-page h4, .xmodule_display.xmodule_StaticTabModule h4 {
   text-transform: none;
   font-family: 'Lato', sans-serif;
@@ -7205,6 +7241,7 @@ div.book-wrapper {
   text-transform: uppercase;
   color: rgba(31, 31, 31, 0.75);
   letter-spacing: 0; }
+
 .a--course-static-page ul li, .a--course-static-page ol li, .a--course-static-page .xmodule_display.xmodule_CapaModule div.problem p, .xmodule_display.xmodule_StaticTabModule ul li, .xmodule_display.xmodule_StaticTabModule ol li, .xmodule_display.xmodule_StaticTabModule .xmodule_display.xmodule_CapaModule div.problem p {
   font-size: 16px; }
 
@@ -7338,8 +7375,10 @@ div.book-wrapper {
     font-size: 1.8rem;
     color: #fff;
     margin: -1rem 0 3rem; }
+
 .a--course-about-01__courseware-button-wrapper #register_error {
   display: inline-block; }
+
 .a--course-about-01__social-share {
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
@@ -7392,6 +7431,7 @@ div.book-wrapper {
     opacity: 0.7; }
     .a--course-about-01__social-share a:hover, .a--course-about-01__social-share a:focus {
       opacity: 1; }
+
 .a--course-about-01__courseware-btn {
   background-color: #f6322b;
   border: none;
@@ -7423,6 +7463,7 @@ div.book-wrapper {
     color: #fff; }
   .a--course-about-01__courseware-btn:hover, .a--course-about-01__courseware-btn:focus {
     color: rgba(255, 255, 255, 0.8); }
+
 .a--course-about-01__overview {
   padding: 3rem 0 5rem;
   background-color: transparent;
@@ -7459,6 +7500,7 @@ div.book-wrapper {
     margin-top: 3rem; }
     .a--course-about-01__overview .teacher .teacher-image img {
       float: none; }
+
 .a--course-about-01__info {
   display: block;
   width: 30%;
@@ -7509,6 +7551,7 @@ div.book-wrapper {
       font-style: normal;
       font-weight: 400;
       display: inline-block; }
+
 .a--course-about-01__content {
   padding-bottom: 4rem; }
   @media (min-width: 992px) {
@@ -7886,6 +7929,7 @@ div.book-wrapper {
       opacity: 0.85; }
   .account-settings-sections .section .u-field-message-help {
     color: #1f1f1f; }
+
 .account-settings-sections .section-header {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -7894,6 +7938,7 @@ div.book-wrapper {
   color: rgba(31, 31, 31, 0.7);
   margin-bottom: 10px;
   padding-bottom: 20px; }
+
 .account-settings-sections a, .account-settings-sections a span {
   color: #3da794;
   -webkit-transition: all 0.3s ease-in-out;
@@ -7903,6 +7948,7 @@ div.book-wrapper {
 
 .view-profile .wrapper-profile {
   width: 100%; }
+
 .view-profile .profile-self .wrapper-profile-field-account-privacy {
   background-color: rgba(31, 31, 31, 0.2);
   padding-top: 20px;
@@ -7940,6 +7986,7 @@ div.book-wrapper {
       border-bottom: 1px solid rgba(31, 31, 31, 0.6); }
       .view-profile .profile-self .wrapper-profile-field-account-privacy .u-field-value select:focus {
         outline: none; }
+
 .view-profile .wrapper-profile-sections {
   display: -webkit-box;
   display: -moz-box;
@@ -7957,6 +8004,7 @@ div.book-wrapper {
   flex-wrap: wrap;
   padding: 30px;
   min-width: 0; }
+
 .view-profile .wrapper-profile-section-one {
   display: -webkit-box;
   display: -moz-box;
@@ -7984,6 +8032,7 @@ div.book-wrapper {
       padding: 0 0 20px 0;
       border: none;
       border-bottom: 1px solid rgba(31, 31, 31, 0.2); } }
+
 .view-profile .wrapper-profile-section-two {
   width: 60%;
   padding-left: 20px; }
@@ -7991,11 +8040,13 @@ div.book-wrapper {
     .view-profile .wrapper-profile-section-two {
       width: 100%;
       padding: 20px 0 0 0; } }
+
 .view-profile .profile-image-field {
   -webkit-flex-shrink: 0;
   -moz-flex-shrink: 0;
   flex-shrink: 0;
   -ms-flex-negative: 0; }
+
 .view-profile .profile-section-one-fields {
   -webkit-flex-grow: 1;
   -moz-flex-grow: 1;
@@ -8016,20 +8067,24 @@ div.book-wrapper {
     top: -3px;
     right: 3px;
     color: #3da794 !important; }
+
 .view-profile .profile-section-two-fields .u-field-title {
   width: 80%;
   color: #3da794; }
+
 .view-profile .profile-section-two-fields .editable-toggle {
   padding: 5px;
   -webkit-transition: all 0.2s ease-in-out;
   transition: all 0.2s ease-in-out; }
   .view-profile .profile-section-two-fields .editable-toggle:hover, .view-profile .profile-section-two-fields .editable-toggle:focus {
     background-color: rgba(61, 167, 148, 0.05); }
+
 .view-profile .profile-section-two-fields .message-can-edit {
   position: relative;
   top: -3px;
   right: 3px;
   color: #3da794 !important; }
+
 .view-profile input {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -8187,6 +8242,7 @@ span#djangopid, span#edxver {
     border-bottom: 0.1rem solid rgba(31, 31, 31, 0.2); }
     .a--dashboard-01__notifications__notification:last-child {
       border-bottom: none; }
+
 .a--dashboard-01__main__container {
   display: -webkit-box;
   display: -moz-box;
@@ -8204,6 +8260,7 @@ span#djangopid, span#edxver {
       -moz-flex-wrap: wrap;
       -ms-flex-wrap: wrap;
       flex-wrap: wrap; } }
+
 .a--dashboard-01__main__content {
   -webkit-flex-shrink: 1;
   -moz-flex-shrink: 1;
@@ -8212,8 +8269,10 @@ span#djangopid, span#edxver {
   width: 100%;
   max-width: 98rem;
   margin: 0 auto; }
+
 .a--dashboard-01__main__search-results {
   padding: 0 0 4rem; }
+
 .a--dashboard-01__main__sidebar {
   -webkit-flex-shrink: 0;
   -moz-flex-shrink: 0;
@@ -8229,8 +8288,10 @@ span#djangopid, span#edxver {
       margin-top: 4rem;
       padding-top: 4rem;
       border-top: 0.1rem solid rgba(31, 31, 31, 0.3); } }
+
 .a--dashboard-01__main__courses {
   padding: 0 0 4rem; }
+
 .a--dashboard-01__promote-catalog {
   padding: 3rem 0;
   border-bottom: 0.1rem solid rgba(31, 31, 31, 0.3);
@@ -8569,8 +8630,10 @@ span#djangopid, span#edxver {
     font-size: 1.8rem;
     color: #fff;
     margin: -1rem 0 3rem; }
+
 .a--course-about-palix__courseware-button-wrapper #register_error {
   display: inline-block; }
+
 .a--course-about-palix__social-share {
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
@@ -8624,6 +8687,7 @@ span#djangopid, span#edxver {
     .a--course-about-palix__social-share a:hover, .a--course-about-palix__social-share a:focus {
       color: #fff;
       opacity: 0.7; }
+
 .a--course-about-palix__courseware-btn {
   border: none;
   display: inline-block;
@@ -8657,6 +8721,7 @@ span#djangopid, span#edxver {
   .a--course-about-palix__courseware-btn:hover, .a--course-about-palix__courseware-btn:focus {
     color: #3da794;
     opacity: 0.75; }
+
 .a--course-about-palix__overview {
   padding: 3rem 0 5rem;
   background-color: transparent;
@@ -8712,6 +8777,7 @@ span#djangopid, span#edxver {
     color: #3da794;
     text-transform: uppercase;
     font-size: 2.4rem; }
+
 .a--course-about-palix__info {
   display: block;
   width: 30%;
@@ -8762,6 +8828,7 @@ span#djangopid, span#edxver {
       font-style: normal;
       font-weight: 700;
       display: inline-block; }
+
 .a--course-about-palix__content {
   padding-bottom: 4rem; }
   @media (min-width: 992px) {
@@ -8773,6 +8840,7 @@ span#djangopid, span#edxver {
       display: -moz-flex;
       display: -ms-flexbox;
       display: flex; } }
+
 .a--course-about-palix article.response {
   padding-bottom: 2rem;
   margin-bottom: 2rem;
@@ -8824,6 +8892,7 @@ span#djangopid, span#edxver {
   @media (max-width: 767px) {
     .a--course-listing-01__section-heading {
       font-size: 2.4rem; } }
+
 .a--course-listing-01__section-text {
   max-width: 92rem;
   margin: 0 auto;
@@ -8881,6 +8950,7 @@ span#djangopid, span#edxver {
       -moz-flex-wrap: wrap;
       -ms-flex-wrap: wrap;
       flex-wrap: wrap; } }
+
 .palix--index-what-learn__graphic {
   width: 24rem;
   margin-right: 6rem;
@@ -8900,6 +8970,7 @@ span#djangopid, span#edxver {
     display: block;
     width: 100%;
     max-width: 24rem; }
+
 .palix--index-what-learn__content {
   width: 100%;
   -webkit-flex-shrink: 1;
@@ -8910,5 +8981,3 @@ span#djangopid, span#edxver {
   -moz-flex-grow: 1;
   flex-grow: 1;
   -ms-flex-positive: 1; }
-
-/*# sourceMappingURL=main.css.map */

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -185,69 +185,53 @@ th {
     color: #000 !important;
     background: transparent !important;
     box-shadow: none !important; }
-
   a,
   a:visited {
     text-decoration: underline; }
-
   a[href]:after {
     content: " (" attr(href) ")"; }
-
   abbr[title]:after {
     content: " (" attr(title) ")"; }
-
   a[href^="javascript:"]:after,
   a[href^="#"]:after {
     content: ""; }
-
   pre,
   blockquote {
     border: 1px solid #999;
     page-break-inside: avoid; }
-
   thead {
     display: table-header-group; }
-
   tr,
   img {
     page-break-inside: avoid; }
-
   img {
     max-width: 100% !important; }
-
   p,
   h2,
   h3 {
     orphans: 3;
     widows: 3; }
-
   h2,
   h3 {
     page-break-after: avoid; }
-
   select {
     background: #fff !important; }
-
   .navbar {
     display: none; }
-
   .table td,
   .table th {
     background-color: #fff !important; }
-
   .btn > .caret,
   .dropup > .btn > .caret {
     border-top-color: #000 !important; }
-
   .label {
     border: 1px solid #000; }
-
   .table {
     border-collapse: collapse !important; }
-
   .table-bordered th,
   .table-bordered td {
     border: 1px solid #ddd !important; } }
+
 * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -535,471 +519,321 @@ hr {
 @media (min-width: 768px) {
   .col-sm-12, .col-sm-11, .col-sm-10, .col-sm-9, .col-sm-8, .col-sm-7, .col-sm-6, .col-sm-5, .col-sm-4, .col-sm-3, .col-sm-2, .col-sm-1 {
     float: left; }
-
   .col-sm-1 {
     width: 8.33333%; }
-
   .col-sm-2 {
     width: 16.66667%; }
-
   .col-sm-3 {
     width: 25%; }
-
   .col-sm-4 {
     width: 33.33333%; }
-
   .col-sm-5 {
     width: 41.66667%; }
-
   .col-sm-6 {
     width: 50%; }
-
   .col-sm-7 {
     width: 58.33333%; }
-
   .col-sm-8 {
     width: 66.66667%; }
-
   .col-sm-9 {
     width: 75%; }
-
   .col-sm-10 {
     width: 83.33333%; }
-
   .col-sm-11 {
     width: 91.66667%; }
-
   .col-sm-12 {
     width: 100%; }
-
   .col-sm-pull-0 {
     right: 0%; }
-
   .col-sm-pull-1 {
     right: 8.33333%; }
-
   .col-sm-pull-2 {
     right: 16.66667%; }
-
   .col-sm-pull-3 {
     right: 25%; }
-
   .col-sm-pull-4 {
     right: 33.33333%; }
-
   .col-sm-pull-5 {
     right: 41.66667%; }
-
   .col-sm-pull-6 {
     right: 50%; }
-
   .col-sm-pull-7 {
     right: 58.33333%; }
-
   .col-sm-pull-8 {
     right: 66.66667%; }
-
   .col-sm-pull-9 {
     right: 75%; }
-
   .col-sm-pull-10 {
     right: 83.33333%; }
-
   .col-sm-pull-11 {
     right: 91.66667%; }
-
   .col-sm-pull-12 {
     right: 100%; }
-
   .col-sm-push-0 {
     left: 0%; }
-
   .col-sm-push-1 {
     left: 8.33333%; }
-
   .col-sm-push-2 {
     left: 16.66667%; }
-
   .col-sm-push-3 {
     left: 25%; }
-
   .col-sm-push-4 {
     left: 33.33333%; }
-
   .col-sm-push-5 {
     left: 41.66667%; }
-
   .col-sm-push-6 {
     left: 50%; }
-
   .col-sm-push-7 {
     left: 58.33333%; }
-
   .col-sm-push-8 {
     left: 66.66667%; }
-
   .col-sm-push-9 {
     left: 75%; }
-
   .col-sm-push-10 {
     left: 83.33333%; }
-
   .col-sm-push-11 {
     left: 91.66667%; }
-
   .col-sm-push-12 {
     left: 100%; }
-
   .col-sm-offset-0 {
     margin-left: 0%; }
-
   .col-sm-offset-1 {
     margin-left: 8.33333%; }
-
   .col-sm-offset-2 {
     margin-left: 16.66667%; }
-
   .col-sm-offset-3 {
     margin-left: 25%; }
-
   .col-sm-offset-4 {
     margin-left: 33.33333%; }
-
   .col-sm-offset-5 {
     margin-left: 41.66667%; }
-
   .col-sm-offset-6 {
     margin-left: 50%; }
-
   .col-sm-offset-7 {
     margin-left: 58.33333%; }
-
   .col-sm-offset-8 {
     margin-left: 66.66667%; }
-
   .col-sm-offset-9 {
     margin-left: 75%; }
-
   .col-sm-offset-10 {
     margin-left: 83.33333%; }
-
   .col-sm-offset-11 {
     margin-left: 91.66667%; }
-
   .col-sm-offset-12 {
     margin-left: 100%; } }
+
 @media (min-width: 992px) {
   .col-md-12, .col-md-11, .col-md-10, .col-md-9, .col-md-8, .col-md-7, .col-md-6, .col-md-5, .col-md-4, .col-md-3, .col-md-2, .col-md-1 {
     float: left; }
-
   .col-md-1 {
     width: 8.33333%; }
-
   .col-md-2 {
     width: 16.66667%; }
-
   .col-md-3 {
     width: 25%; }
-
   .col-md-4 {
     width: 33.33333%; }
-
   .col-md-5 {
     width: 41.66667%; }
-
   .col-md-6 {
     width: 50%; }
-
   .col-md-7 {
     width: 58.33333%; }
-
   .col-md-8 {
     width: 66.66667%; }
-
   .col-md-9 {
     width: 75%; }
-
   .col-md-10 {
     width: 83.33333%; }
-
   .col-md-11 {
     width: 91.66667%; }
-
   .col-md-12 {
     width: 100%; }
-
   .col-md-pull-0 {
     right: 0%; }
-
   .col-md-pull-1 {
     right: 8.33333%; }
-
   .col-md-pull-2 {
     right: 16.66667%; }
-
   .col-md-pull-3 {
     right: 25%; }
-
   .col-md-pull-4 {
     right: 33.33333%; }
-
   .col-md-pull-5 {
     right: 41.66667%; }
-
   .col-md-pull-6 {
     right: 50%; }
-
   .col-md-pull-7 {
     right: 58.33333%; }
-
   .col-md-pull-8 {
     right: 66.66667%; }
-
   .col-md-pull-9 {
     right: 75%; }
-
   .col-md-pull-10 {
     right: 83.33333%; }
-
   .col-md-pull-11 {
     right: 91.66667%; }
-
   .col-md-pull-12 {
     right: 100%; }
-
   .col-md-push-0 {
     left: 0%; }
-
   .col-md-push-1 {
     left: 8.33333%; }
-
   .col-md-push-2 {
     left: 16.66667%; }
-
   .col-md-push-3 {
     left: 25%; }
-
   .col-md-push-4 {
     left: 33.33333%; }
-
   .col-md-push-5 {
     left: 41.66667%; }
-
   .col-md-push-6 {
     left: 50%; }
-
   .col-md-push-7 {
     left: 58.33333%; }
-
   .col-md-push-8 {
     left: 66.66667%; }
-
   .col-md-push-9 {
     left: 75%; }
-
   .col-md-push-10 {
     left: 83.33333%; }
-
   .col-md-push-11 {
     left: 91.66667%; }
-
   .col-md-push-12 {
     left: 100%; }
-
   .col-md-offset-0 {
     margin-left: 0%; }
-
   .col-md-offset-1 {
     margin-left: 8.33333%; }
-
   .col-md-offset-2 {
     margin-left: 16.66667%; }
-
   .col-md-offset-3 {
     margin-left: 25%; }
-
   .col-md-offset-4 {
     margin-left: 33.33333%; }
-
   .col-md-offset-5 {
     margin-left: 41.66667%; }
-
   .col-md-offset-6 {
     margin-left: 50%; }
-
   .col-md-offset-7 {
     margin-left: 58.33333%; }
-
   .col-md-offset-8 {
     margin-left: 66.66667%; }
-
   .col-md-offset-9 {
     margin-left: 75%; }
-
   .col-md-offset-10 {
     margin-left: 83.33333%; }
-
   .col-md-offset-11 {
     margin-left: 91.66667%; }
-
   .col-md-offset-12 {
     margin-left: 100%; } }
+
 @media (min-width: 1200px) {
   .col-lg-12, .col-lg-11, .col-lg-10, .col-lg-9, .col-lg-8, .col-lg-7, .col-lg-6, .col-lg-5, .col-lg-4, .col-lg-3, .col-lg-2, .col-lg-1 {
     float: left; }
-
   .col-lg-1 {
     width: 8.33333%; }
-
   .col-lg-2 {
     width: 16.66667%; }
-
   .col-lg-3 {
     width: 25%; }
-
   .col-lg-4 {
     width: 33.33333%; }
-
   .col-lg-5 {
     width: 41.66667%; }
-
   .col-lg-6 {
     width: 50%; }
-
   .col-lg-7 {
     width: 58.33333%; }
-
   .col-lg-8 {
     width: 66.66667%; }
-
   .col-lg-9 {
     width: 75%; }
-
   .col-lg-10 {
     width: 83.33333%; }
-
   .col-lg-11 {
     width: 91.66667%; }
-
   .col-lg-12 {
     width: 100%; }
-
   .col-lg-pull-0 {
     right: 0%; }
-
   .col-lg-pull-1 {
     right: 8.33333%; }
-
   .col-lg-pull-2 {
     right: 16.66667%; }
-
   .col-lg-pull-3 {
     right: 25%; }
-
   .col-lg-pull-4 {
     right: 33.33333%; }
-
   .col-lg-pull-5 {
     right: 41.66667%; }
-
   .col-lg-pull-6 {
     right: 50%; }
-
   .col-lg-pull-7 {
     right: 58.33333%; }
-
   .col-lg-pull-8 {
     right: 66.66667%; }
-
   .col-lg-pull-9 {
     right: 75%; }
-
   .col-lg-pull-10 {
     right: 83.33333%; }
-
   .col-lg-pull-11 {
     right: 91.66667%; }
-
   .col-lg-pull-12 {
     right: 100%; }
-
   .col-lg-push-0 {
     left: 0%; }
-
   .col-lg-push-1 {
     left: 8.33333%; }
-
   .col-lg-push-2 {
     left: 16.66667%; }
-
   .col-lg-push-3 {
     left: 25%; }
-
   .col-lg-push-4 {
     left: 33.33333%; }
-
   .col-lg-push-5 {
     left: 41.66667%; }
-
   .col-lg-push-6 {
     left: 50%; }
-
   .col-lg-push-7 {
     left: 58.33333%; }
-
   .col-lg-push-8 {
     left: 66.66667%; }
-
   .col-lg-push-9 {
     left: 75%; }
-
   .col-lg-push-10 {
     left: 83.33333%; }
-
   .col-lg-push-11 {
     left: 91.66667%; }
-
   .col-lg-push-12 {
     left: 100%; }
-
   .col-lg-offset-0 {
     margin-left: 0%; }
-
   .col-lg-offset-1 {
     margin-left: 8.33333%; }
-
   .col-lg-offset-2 {
     margin-left: 16.66667%; }
-
   .col-lg-offset-3 {
     margin-left: 25%; }
-
   .col-lg-offset-4 {
     margin-left: 33.33333%; }
-
   .col-lg-offset-5 {
     margin-left: 41.66667%; }
-
   .col-lg-offset-6 {
     margin-left: 50%; }
-
   .col-lg-offset-7 {
     margin-left: 58.33333%; }
-
   .col-lg-offset-8 {
     margin-left: 66.66667%; }
-
   .col-lg-offset-9 {
     margin-left: 75%; }
-
   .col-lg-offset-10 {
     margin-left: 83.33333%; }
-
   .col-lg-offset-11 {
     margin-left: 91.66667%; }
-
   .col-lg-offset-12 {
     margin-left: 100%; } }
+
 .fade {
   opacity: 0;
   -webkit-transition: opacity 0.15s linear;
@@ -1094,6 +928,7 @@ hr {
 
 .open > .dropdown-menu {
   display: block; }
+
 .open > a {
   outline: 0; }
 
@@ -1129,6 +964,7 @@ hr {
   border-top: 0;
   border-bottom: 4px solid;
   content: ""; }
+
 .dropup .dropdown-menu,
 .navbar-fixed-bottom .dropdown .dropdown-menu {
   top: auto;
@@ -1142,6 +978,7 @@ hr {
   .navbar-right .dropdown-menu-left {
     left: 0;
     right: auto; } }
+
 .modal-open {
   overflow: hidden; }
 
@@ -1239,16 +1076,14 @@ hr {
   .modal-dialog {
     width: 600px;
     margin: 30px auto; }
-
   .modal-content {
     -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5); }
-
   .modal-sm {
     width: 300px; }
-
   .modal-lg {
     width: 900px; } }
+
 /*!
 Animate.css - http://daneden.me/animate
 Licensed under the MIT license - http://opensource.org/licenses/MIT
@@ -1298,6 +1133,7 @@ Copyright (c) 2015 Daniel Eden
   90% {
     -webkit-transform: translate3d(0, -4px, 0);
     transform: translate3d(0, -4px, 0); } }
+
 @keyframes bounce {
   from, 20%, 53%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1317,6 +1153,7 @@ Copyright (c) 2015 Daniel Eden
   90% {
     -webkit-transform: translate3d(0, -4px, 0);
     transform: translate3d(0, -4px, 0); } }
+
 .bounce {
   -webkit-animation-name: bounce;
   animation-name: bounce;
@@ -1328,11 +1165,13 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1; }
   25%, 75% {
     opacity: 0; } }
+
 @keyframes flash {
   from, 50%, to {
     opacity: 1; }
   25%, 75% {
     opacity: 0; } }
+
 .flash {
   -webkit-animation-name: flash;
   animation-name: flash; }
@@ -1348,6 +1187,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 @keyframes pulse {
   from {
     -webkit-transform: scale3d(1, 1, 1);
@@ -1358,6 +1198,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 .pulse {
   -webkit-animation-name: pulse;
   animation-name: pulse; }
@@ -1384,6 +1225,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 @keyframes rubberBand {
   from {
     -webkit-transform: scale3d(1, 1, 1);
@@ -1406,6 +1248,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 .rubberBand {
   -webkit-animation-name: rubberBand;
   animation-name: rubberBand; }
@@ -1420,6 +1263,7 @@ Copyright (c) 2015 Daniel Eden
   20%, 40%, 60%, 80% {
     -webkit-transform: translate3d(10px, 0, 0);
     transform: translate3d(10px, 0, 0); } }
+
 @keyframes shake {
   from, to {
     -webkit-transform: translate3d(0, 0, 0);
@@ -1430,6 +1274,7 @@ Copyright (c) 2015 Daniel Eden
   20%, 40%, 60%, 80% {
     -webkit-transform: translate3d(10px, 0, 0);
     transform: translate3d(10px, 0, 0); } }
+
 .shake {
   -webkit-animation-name: shake;
   animation-name: shake; }
@@ -1450,6 +1295,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: rotate3d(0, 0, 1, 0deg);
     transform: rotate3d(0, 0, 1, 0deg); } }
+
 @keyframes swing {
   20% {
     -webkit-transform: rotate3d(0, 0, 1, 15deg);
@@ -1466,6 +1312,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: rotate3d(0, 0, 1, 0deg);
     transform: rotate3d(0, 0, 1, 0deg); } }
+
 .swing {
   -webkit-transform-origin: top center;
   transform-origin: top center;
@@ -1488,6 +1335,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 @keyframes tada {
   from {
     -webkit-transform: scale3d(1, 1, 1);
@@ -1504,6 +1352,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 .tada {
   -webkit-animation-name: tada;
   animation-name: tada; }
@@ -1531,6 +1380,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes wobble {
   from {
     -webkit-transform: none;
@@ -1553,6 +1403,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 .wobble {
   -webkit-animation-name: wobble;
   animation-name: wobble; }
@@ -1577,11 +1428,12 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: skewX(-0.78125deg) skewY(-0.78125deg);
     transform: skewX(-0.78125deg) skewY(-0.78125deg); }
   77.7% {
-    -webkit-transform: skewX(0.39063deg) skewY(0.39063deg);
-    transform: skewX(0.39063deg) skewY(0.39063deg); }
+    -webkit-transform: skewX(0.39062deg) skewY(0.39062deg);
+    transform: skewX(0.39062deg) skewY(0.39062deg); }
   88.8% {
     -webkit-transform: skewX(-0.19531deg) skewY(-0.19531deg);
     transform: skewX(-0.19531deg) skewY(-0.19531deg); } }
+
 @keyframes jello {
   from, 11.1%, to {
     -webkit-transform: none;
@@ -1602,11 +1454,12 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: skewX(-0.78125deg) skewY(-0.78125deg);
     transform: skewX(-0.78125deg) skewY(-0.78125deg); }
   77.7% {
-    -webkit-transform: skewX(0.39063deg) skewY(0.39063deg);
-    transform: skewX(0.39063deg) skewY(0.39063deg); }
+    -webkit-transform: skewX(0.39062deg) skewY(0.39062deg);
+    transform: skewX(0.39062deg) skewY(0.39062deg); }
   88.8% {
     -webkit-transform: skewX(-0.19531deg) skewY(-0.19531deg);
     transform: skewX(-0.19531deg) skewY(-0.19531deg); } }
+
 .jello {
   -webkit-animation-name: jello;
   animation-name: jello;
@@ -1638,6 +1491,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 @keyframes bounceIn {
   from, 20%, 40%, 60%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1663,6 +1517,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: scale3d(1, 1, 1);
     transform: scale3d(1, 1, 1); } }
+
 .bounceIn {
   -webkit-animation-name: bounceIn;
   animation-name: bounceIn; }
@@ -1688,6 +1543,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes bounceInDown {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1709,6 +1565,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 .bounceInDown {
   -webkit-animation-name: bounceInDown;
   animation-name: bounceInDown; }
@@ -1734,6 +1591,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes bounceInLeft {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1755,6 +1613,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 .bounceInLeft {
   -webkit-animation-name: bounceInLeft;
   animation-name: bounceInLeft; }
@@ -1780,6 +1639,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes bounceInRight {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1801,6 +1661,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: none;
     transform: none; } }
+
 .bounceInRight {
   -webkit-animation-name: bounceInRight;
   animation-name: bounceInRight; }
@@ -1826,6 +1687,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 @keyframes bounceInUp {
   from, 60%, 75%, 90%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
@@ -1847,6 +1709,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 .bounceInUp {
   -webkit-animation-name: bounceInUp;
   animation-name: bounceInUp; }
@@ -1863,6 +1726,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: scale3d(0.3, 0.3, 0.3);
     transform: scale3d(0.3, 0.3, 0.3); } }
+
 @keyframes bounceOut {
   20% {
     -webkit-transform: scale3d(0.9, 0.9, 0.9);
@@ -1875,6 +1739,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: scale3d(0.3, 0.3, 0.3);
     transform: scale3d(0.3, 0.3, 0.3); } }
+
 .bounceOut {
   -webkit-animation-name: bounceOut;
   animation-name: bounceOut; }
@@ -1891,6 +1756,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
+
 @keyframes bounceOutDown {
   20% {
     -webkit-transform: translate3d(0, 10px, 0);
@@ -1903,6 +1769,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
+
 .bounceOutDown {
   -webkit-animation-name: bounceOutDown;
   animation-name: bounceOutDown; }
@@ -1916,6 +1783,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
+
 @keyframes bounceOutLeft {
   20% {
     opacity: 1;
@@ -1925,6 +1793,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
+
 .bounceOutLeft {
   -webkit-animation-name: bounceOutLeft;
   animation-name: bounceOutLeft; }
@@ -1938,6 +1807,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
+
 @keyframes bounceOutRight {
   20% {
     opacity: 1;
@@ -1947,6 +1817,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
+
 .bounceOutRight {
   -webkit-animation-name: bounceOutRight;
   animation-name: bounceOutRight; }
@@ -1963,6 +1834,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
+
 @keyframes bounceOutUp {
   20% {
     -webkit-transform: translate3d(0, -10px, 0);
@@ -1975,6 +1847,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
+
 .bounceOutUp {
   -webkit-animation-name: bounceOutUp;
   animation-name: bounceOutUp; }
@@ -1984,11 +1857,13 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0; }
   to {
     opacity: 1; } }
+
 @keyframes fadeIn {
   from {
     opacity: 0; }
   to {
     opacity: 1; } }
+
 .fadeIn {
   -webkit-animation-name: fadeIn;
   animation-name: fadeIn; }
@@ -2002,6 +1877,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInDown {
   from {
     opacity: 0;
@@ -2011,6 +1887,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInDown {
   -webkit-animation-name: fadeInDown;
   animation-name: fadeInDown; }
@@ -2024,6 +1901,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInDownBig {
   from {
     opacity: 0;
@@ -2033,6 +1911,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInDownBig {
   -webkit-animation-name: fadeInDownBig;
   animation-name: fadeInDownBig; }
@@ -2046,6 +1925,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInLeft {
   from {
     opacity: 0;
@@ -2055,6 +1935,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInLeft {
   -webkit-animation-name: fadeInLeft;
   animation-name: fadeInLeft; }
@@ -2068,6 +1949,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInLeftBig {
   from {
     opacity: 0;
@@ -2077,6 +1959,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInLeftBig {
   -webkit-animation-name: fadeInLeftBig;
   animation-name: fadeInLeftBig; }
@@ -2090,6 +1973,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInRight {
   from {
     opacity: 0;
@@ -2099,6 +1983,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInRight {
   -webkit-animation-name: fadeInRight;
   animation-name: fadeInRight; }
@@ -2112,6 +1997,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInRightBig {
   from {
     opacity: 0;
@@ -2121,6 +2007,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInRightBig {
   -webkit-animation-name: fadeInRightBig;
   animation-name: fadeInRightBig; }
@@ -2134,6 +2021,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInUp {
   from {
     opacity: 0;
@@ -2143,6 +2031,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInUp {
   -webkit-animation-name: fadeInUp;
   animation-name: fadeInUp; }
@@ -2156,6 +2045,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes fadeInUpBig {
   from {
     opacity: 0;
@@ -2165,6 +2055,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .fadeInUpBig {
   -webkit-animation-name: fadeInUpBig;
   animation-name: fadeInUpBig; }
@@ -2174,11 +2065,13 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1; }
   to {
     opacity: 0; } }
+
 @keyframes fadeOut {
   from {
     opacity: 1; }
   to {
     opacity: 0; } }
+
 .fadeOut {
   -webkit-animation-name: fadeOut;
   animation-name: fadeOut; }
@@ -2190,6 +2083,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
+
 @keyframes fadeOutDown {
   from {
     opacity: 1; }
@@ -2197,6 +2091,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
+
 .fadeOutDown {
   -webkit-animation-name: fadeOutDown;
   animation-name: fadeOutDown; }
@@ -2208,6 +2103,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
+
 @keyframes fadeOutDownBig {
   from {
     opacity: 1; }
@@ -2215,6 +2111,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, 2000px, 0);
     transform: translate3d(0, 2000px, 0); } }
+
 .fadeOutDownBig {
   -webkit-animation-name: fadeOutDownBig;
   animation-name: fadeOutDownBig; }
@@ -2226,6 +2123,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
+
 @keyframes fadeOutLeft {
   from {
     opacity: 1; }
@@ -2233,6 +2131,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
+
 .fadeOutLeft {
   -webkit-animation-name: fadeOutLeft;
   animation-name: fadeOutLeft; }
@@ -2244,6 +2143,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
+
 @keyframes fadeOutLeftBig {
   from {
     opacity: 1; }
@@ -2251,6 +2151,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(-2000px, 0, 0);
     transform: translate3d(-2000px, 0, 0); } }
+
 .fadeOutLeftBig {
   -webkit-animation-name: fadeOutLeftBig;
   animation-name: fadeOutLeftBig; }
@@ -2262,6 +2163,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
+
 @keyframes fadeOutRight {
   from {
     opacity: 1; }
@@ -2269,6 +2171,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
+
 .fadeOutRight {
   -webkit-animation-name: fadeOutRight;
   animation-name: fadeOutRight; }
@@ -2280,6 +2183,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
+
 @keyframes fadeOutRightBig {
   from {
     opacity: 1; }
@@ -2287,6 +2191,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(2000px, 0, 0);
     transform: translate3d(2000px, 0, 0); } }
+
 .fadeOutRightBig {
   -webkit-animation-name: fadeOutRightBig;
   animation-name: fadeOutRightBig; }
@@ -2298,6 +2203,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
+
 @keyframes fadeOutUp {
   from {
     opacity: 1; }
@@ -2305,6 +2211,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
+
 .fadeOutUp {
   -webkit-animation-name: fadeOutUp;
   animation-name: fadeOutUp; }
@@ -2316,6 +2223,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
+
 @keyframes fadeOutUpBig {
   from {
     opacity: 1; }
@@ -2323,6 +2231,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(0, -2000px, 0);
     transform: translate3d(0, -2000px, 0); } }
+
 .fadeOutUpBig {
   -webkit-animation-name: fadeOutUpBig;
   animation-name: fadeOutUpBig; }
@@ -2353,6 +2262,7 @@ Copyright (c) 2015 Daniel Eden
     transform: perspective(400px);
     -webkit-animation-timing-function: ease-in;
     animation-timing-function: ease-in; } }
+
 @keyframes flip {
   from {
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, -360deg);
@@ -2379,6 +2289,7 @@ Copyright (c) 2015 Daniel Eden
     transform: perspective(400px);
     -webkit-animation-timing-function: ease-in;
     animation-timing-function: ease-in; } }
+
 .animated.flip {
   -webkit-backface-visibility: visible;
   backface-visibility: visible;
@@ -2407,6 +2318,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
+
 @keyframes flipInX {
   from {
     -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
@@ -2429,6 +2341,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
+
 .flipInX {
   -webkit-backface-visibility: visible !important;
   backface-visibility: visible !important;
@@ -2457,6 +2370,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
+
 @keyframes flipInY {
   from {
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
@@ -2479,6 +2393,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: perspective(400px);
     transform: perspective(400px); } }
+
 .flipInY {
   -webkit-backface-visibility: visible !important;
   backface-visibility: visible !important;
@@ -2497,6 +2412,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     opacity: 0; } }
+
 @keyframes flipOutX {
   from {
     -webkit-transform: perspective(400px);
@@ -2509,6 +2425,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     transform: perspective(400px) rotate3d(1, 0, 0, 90deg);
     opacity: 0; } }
+
 .flipOutX {
   -webkit-animation-name: flipOutX;
   animation-name: flipOutX;
@@ -2527,6 +2444,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     opacity: 0; } }
+
 @keyframes flipOutY {
   from {
     -webkit-transform: perspective(400px);
@@ -2539,6 +2457,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     transform: perspective(400px) rotate3d(0, 1, 0, 90deg);
     opacity: 0; } }
+
 .flipOutY {
   -webkit-backface-visibility: visible !important;
   backface-visibility: visible !important;
@@ -2562,6 +2481,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes lightSpeedIn {
   from {
     -webkit-transform: translate3d(100%, 0, 0) skewX(-30deg);
@@ -2579,6 +2499,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .lightSpeedIn {
   -webkit-animation-name: lightSpeedIn;
   animation-name: lightSpeedIn;
@@ -2592,6 +2513,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(100%, 0, 0) skewX(30deg);
     transform: translate3d(100%, 0, 0) skewX(30deg);
     opacity: 0; } }
+
 @keyframes lightSpeedOut {
   from {
     opacity: 1; }
@@ -2599,6 +2521,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(100%, 0, 0) skewX(30deg);
     transform: translate3d(100%, 0, 0) skewX(30deg);
     opacity: 0; } }
+
 .lightSpeedOut {
   -webkit-animation-name: lightSpeedOut;
   animation-name: lightSpeedOut;
@@ -2618,6 +2541,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes rotateIn {
   from {
     -webkit-transform-origin: center;
@@ -2631,6 +2555,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .rotateIn {
   -webkit-animation-name: rotateIn;
   animation-name: rotateIn; }
@@ -2648,6 +2573,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes rotateInDownLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2661,6 +2587,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .rotateInDownLeft {
   -webkit-animation-name: rotateInDownLeft;
   animation-name: rotateInDownLeft; }
@@ -2678,6 +2605,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes rotateInDownRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2691,6 +2619,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .rotateInDownRight {
   -webkit-animation-name: rotateInDownRight;
   animation-name: rotateInDownRight; }
@@ -2708,6 +2637,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes rotateInUpLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2721,6 +2651,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .rotateInUpLeft {
   -webkit-animation-name: rotateInUpLeft;
   animation-name: rotateInUpLeft; }
@@ -2738,6 +2669,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 @keyframes rotateInUpRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2751,6 +2683,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: none;
     transform: none;
     opacity: 1; } }
+
 .rotateInUpRight {
   -webkit-animation-name: rotateInUpRight;
   animation-name: rotateInUpRight; }
@@ -2766,6 +2699,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 200deg);
     transform: rotate3d(0, 0, 1, 200deg);
     opacity: 0; } }
+
 @keyframes rotateOut {
   from {
     -webkit-transform-origin: center;
@@ -2777,6 +2711,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 200deg);
     transform: rotate3d(0, 0, 1, 200deg);
     opacity: 0; } }
+
 .rotateOut {
   -webkit-animation-name: rotateOut;
   animation-name: rotateOut; }
@@ -2792,6 +2727,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 45deg);
     transform: rotate3d(0, 0, 1, 45deg);
     opacity: 0; } }
+
 @keyframes rotateOutDownLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2803,6 +2739,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 45deg);
     transform: rotate3d(0, 0, 1, 45deg);
     opacity: 0; } }
+
 .rotateOutDownLeft {
   -webkit-animation-name: rotateOutDownLeft;
   animation-name: rotateOutDownLeft; }
@@ -2818,6 +2755,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
+
 @keyframes rotateOutDownRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2829,6 +2767,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
+
 .rotateOutDownRight {
   -webkit-animation-name: rotateOutDownRight;
   animation-name: rotateOutDownRight; }
@@ -2844,6 +2783,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
+
 @keyframes rotateOutUpLeft {
   from {
     -webkit-transform-origin: left bottom;
@@ -2855,6 +2795,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, -45deg);
     transform: rotate3d(0, 0, 1, -45deg);
     opacity: 0; } }
+
 .rotateOutUpLeft {
   -webkit-animation-name: rotateOutUpLeft;
   animation-name: rotateOutUpLeft; }
@@ -2870,6 +2811,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 90deg);
     transform: rotate3d(0, 0, 1, 90deg);
     opacity: 0; } }
+
 @keyframes rotateOutUpRight {
   from {
     -webkit-transform-origin: right bottom;
@@ -2881,6 +2823,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: rotate3d(0, 0, 1, 90deg);
     transform: rotate3d(0, 0, 1, 90deg);
     opacity: 0; } }
+
 .rotateOutUpRight {
   -webkit-animation-name: rotateOutUpRight;
   animation-name: rotateOutUpRight; }
@@ -2910,6 +2853,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(0, 700px, 0);
     transform: translate3d(0, 700px, 0);
     opacity: 0; } }
+
 @keyframes hinge {
   0% {
     -webkit-transform-origin: top left;
@@ -2935,6 +2879,7 @@ Copyright (c) 2015 Daniel Eden
     -webkit-transform: translate3d(0, 700px, 0);
     transform: translate3d(0, 700px, 0);
     opacity: 0; } }
+
 .hinge {
   -webkit-animation-name: hinge;
   animation-name: hinge; }
@@ -2949,6 +2894,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 @keyframes rollIn {
   from {
     opacity: 0;
@@ -2958,6 +2904,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 1;
     -webkit-transform: none;
     transform: none; } }
+
 .rollIn {
   -webkit-animation-name: rollIn;
   animation-name: rollIn; }
@@ -2970,6 +2917,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg);
     transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg); } }
+
 @keyframes rollOut {
   from {
     opacity: 1; }
@@ -2977,6 +2925,7 @@ Copyright (c) 2015 Daniel Eden
     opacity: 0;
     -webkit-transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg);
     transform: translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg); } }
+
 .rollOut {
   -webkit-animation-name: rollOut;
   animation-name: rollOut; }
@@ -2988,6 +2937,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   50% {
     opacity: 1; } }
+
 @keyframes zoomIn {
   from {
     opacity: 0;
@@ -2995,6 +2945,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   50% {
     opacity: 1; } }
+
 .zoomIn {
   -webkit-animation-name: zoomIn;
   animation-name: zoomIn; }
@@ -3012,6 +2963,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomInDown {
   from {
     opacity: 0;
@@ -3025,6 +2977,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomInDown {
   -webkit-animation-name: zoomInDown;
   animation-name: zoomInDown; }
@@ -3042,6 +2995,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomInLeft {
   from {
     opacity: 0;
@@ -3055,6 +3009,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomInLeft {
   -webkit-animation-name: zoomInLeft;
   animation-name: zoomInLeft; }
@@ -3072,6 +3027,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomInRight {
   from {
     opacity: 0;
@@ -3085,6 +3041,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomInRight {
   -webkit-animation-name: zoomInRight;
   animation-name: zoomInRight; }
@@ -3102,6 +3059,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomInUp {
   from {
     opacity: 0;
@@ -3115,6 +3073,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0);
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomInUp {
   -webkit-animation-name: zoomInUp;
   animation-name: zoomInUp; }
@@ -3128,6 +3087,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   to {
     opacity: 0; } }
+
 @keyframes zoomOut {
   from {
     opacity: 1; }
@@ -3137,6 +3097,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale3d(0.3, 0.3, 0.3); }
   to {
     opacity: 0; } }
+
 .zoomOut {
   -webkit-animation-name: zoomOut;
   animation-name: zoomOut; }
@@ -3156,6 +3117,7 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomOutDown {
   40% {
     opacity: 1;
@@ -3171,6 +3133,7 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomOutDown {
   -webkit-animation-name: zoomOutDown;
   animation-name: zoomOutDown; }
@@ -3186,6 +3149,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(-2000px, 0, 0);
     -webkit-transform-origin: left center;
     transform-origin: left center; } }
+
 @keyframes zoomOutLeft {
   40% {
     opacity: 1;
@@ -3197,6 +3161,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(-2000px, 0, 0);
     -webkit-transform-origin: left center;
     transform-origin: left center; } }
+
 .zoomOutLeft {
   -webkit-animation-name: zoomOutLeft;
   animation-name: zoomOutLeft; }
@@ -3212,6 +3177,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(2000px, 0, 0);
     -webkit-transform-origin: right center;
     transform-origin: right center; } }
+
 @keyframes zoomOutRight {
   40% {
     opacity: 1;
@@ -3223,6 +3189,7 @@ Copyright (c) 2015 Daniel Eden
     transform: scale(0.1) translate3d(2000px, 0, 0);
     -webkit-transform-origin: right center;
     transform-origin: right center; } }
+
 .zoomOutRight {
   -webkit-animation-name: zoomOutRight;
   animation-name: zoomOutRight; }
@@ -3242,6 +3209,7 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 @keyframes zoomOutUp {
   40% {
     opacity: 1;
@@ -3257,6 +3225,7 @@ Copyright (c) 2015 Daniel Eden
     transform-origin: center bottom;
     -webkit-animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1); } }
+
 .zoomOutUp {
   -webkit-animation-name: zoomOutUp;
   animation-name: zoomOutUp; }
@@ -3269,6 +3238,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 @keyframes slideInDown {
   from {
     -webkit-transform: translate3d(0, -100%, 0);
@@ -3277,6 +3247,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 .slideInDown {
   -webkit-animation-name: slideInDown;
   animation-name: slideInDown; }
@@ -3289,6 +3260,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 @keyframes slideInLeft {
   from {
     -webkit-transform: translate3d(-100%, 0, 0);
@@ -3297,6 +3269,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 .slideInLeft {
   -webkit-animation-name: slideInLeft;
   animation-name: slideInLeft; }
@@ -3309,6 +3282,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 @keyframes slideInRight {
   from {
     -webkit-transform: translate3d(100%, 0, 0);
@@ -3317,6 +3291,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 .slideInRight {
   -webkit-animation-name: slideInRight;
   animation-name: slideInRight; }
@@ -3329,6 +3304,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 @keyframes slideInUp {
   from {
     -webkit-transform: translate3d(0, 100%, 0);
@@ -3337,6 +3313,7 @@ Copyright (c) 2015 Daniel Eden
   to {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0); } }
+
 .slideInUp {
   -webkit-animation-name: slideInUp;
   animation-name: slideInUp; }
@@ -3349,6 +3326,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
+
 @keyframes slideOutDown {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3357,6 +3335,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0); } }
+
 .slideOutDown {
   -webkit-animation-name: slideOutDown;
   animation-name: slideOutDown; }
@@ -3369,6 +3348,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
+
 @keyframes slideOutLeft {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3377,6 +3357,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0); } }
+
 .slideOutLeft {
   -webkit-animation-name: slideOutLeft;
   animation-name: slideOutLeft; }
@@ -3389,6 +3370,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
+
 @keyframes slideOutRight {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3397,6 +3379,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0); } }
+
 .slideOutRight {
   -webkit-animation-name: slideOutRight;
   animation-name: slideOutRight; }
@@ -3409,6 +3392,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
+
 @keyframes slideOutUp {
   from {
     -webkit-transform: translate3d(0, 0, 0);
@@ -3417,6 +3401,7 @@ Copyright (c) 2015 Daniel Eden
     visibility: hidden;
     -webkit-transform: translate3d(0, -100%, 0);
     transform: translate3d(0, -100%, 0); } }
+
 .slideOutUp {
   -webkit-animation-name: slideOutUp;
   animation-name: slideOutUp; }
@@ -3442,6 +3427,7 @@ h2 {
   text-shadow: none;
   border: none;
   outline: none; }
+
 .a--container input[type="submit"]:active:not(:disabled), div.book-wrapper input[type="submit"]:active:not(:disabled), .a--container input[type="submit"]:focus:not(:disabled), div.book-wrapper input[type="submit"]:focus:not(:disabled), .a--container input[type="button"]:active:not(:disabled), div.book-wrapper input[type="button"]:active:not(:disabled), .a--container input[type="button"]:focus:not(:disabled), div.book-wrapper input[type="button"]:focus:not(:disabled), .a--container button:active:not(:disabled), div.book-wrapper button:active:not(:disabled), .a--container button:focus:not(:disabled), div.book-wrapper button:focus:not(:disabled), .a--container .button:active:not(:disabled), div.book-wrapper .button:active:not(:disabled) {
   box-shadow: none; }
 
@@ -3757,6 +3743,7 @@ span.a--underlined {
   max-height: 0;
   overflow: hidden;
   opacity: 0; }
+
 .a--expanding-section.a--expanded .a--expanding-section__target {
   max-height: 100rem;
   opacity: 1; }
@@ -4101,6 +4088,7 @@ a.new-post-btn {
       font-style: normal;
       font-weight: 400;
       margin-right: 1rem; }
+
 .a--header-design-01 .a--site-menu__container {
   margin: 0;
   font-size: 1.5rem;
@@ -4128,6 +4116,7 @@ a.new-post-btn {
   .a--header-design-01 .a--site-menu__container ul {
     padding: 0;
     margin: 0; }
+
 .a--header-design-01 .a--site-menu__group {
   display: inline-block;
   padding: 0 2rem; }
@@ -4196,6 +4185,7 @@ a.new-post-btn {
         display: none; }
   .a--header-design-01 .a--site-menu__group.a--user-avatar {
     color: rgba(31, 31, 31, 0.6); }
+
 .a--header-design-01 button.a--site-nav__mobile-toggle {
   color: #fff;
   font-size: 2rem;
@@ -4252,6 +4242,7 @@ a.new-post-btn {
     -ms-transform: translateY(1.5rem);
     -o-transform: translateY(1.5rem);
     transform: translateY(1.5rem); }
+
 @-webkit-keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4262,6 +4253,7 @@ a.new-post-btn {
   100% {
     -webkit-transform: scale(0.2);
     opacity: 0.1; } }
+
 @-moz-keyframes togglePulsar {
   0% {
     -moz-transform: scale(0.2);
@@ -4272,6 +4264,7 @@ a.new-post-btn {
   100% {
     -moz-transform: scale(0.2);
     opacity: 0.1; } }
+
 @keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4336,6 +4329,7 @@ a.new-post-btn {
       width: 3.06rem; }
   .a--header-design-01 button.a--site-nav__mobile-toggle.a--toggled .a--toggle-pulsar {
     display: none; }
+
 .a--header-design-01 ul.a--slide-menu__container li {
   display: block; }
   .a--header-design-01 ul.a--slide-menu__container li a {
@@ -4357,6 +4351,7 @@ a.new-post-btn {
     width: 5rem;
     height: 0.2rem;
     background-color: rgba(255, 255, 255, 0.4); }
+
 .a--header-design-01 .a--slide-menu__container, .a--header-design-01 ul.a--slide-menu__container {
   position: absolute;
   z-index: 1001;
@@ -4551,6 +4546,7 @@ a.new-post-btn {
       font-style: normal;
       font-weight: 400;
       margin-right: 1rem; }
+
 .a--header-design-02 .a--site-menu__container {
   margin: 0;
   font-size: 1.5rem;
@@ -4579,6 +4575,7 @@ a.new-post-btn {
   .a--header-design-02 .a--site-menu__container ul {
     padding: 0;
     margin: 0; }
+
 .a--header-design-02 .a--site-menu__group {
   display: inline-block;
   padding: 0 2rem; }
@@ -4646,10 +4643,12 @@ a.new-post-btn {
         display: none; }
   .a--header-design-02 .a--site-menu__group.a--user-avatar {
     color: rgba(31, 31, 31, 0.6); }
+
 .a--header-design-02 .a--slide-menu {
   border-left: 0.2rem solid rgba(31, 31, 31, 0.2);
   margin-left: 2rem;
   padding-left: 4rem !important; }
+
 .a--header-design-02 button.a--site-nav__mobile-toggle {
   color: #fff;
   font-size: 2rem;
@@ -4747,6 +4746,7 @@ a.new-post-btn {
       -ms-transform: translateX(0.5rem) translateY(0.65rem) rotate(-135deg);
       -o-transform: translateX(0.5rem) translateY(0.65rem) rotate(-135deg);
       transform: translateX(0.5rem) translateY(0.65rem) rotate(-135deg); }
+
 @-webkit-keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4757,6 +4757,7 @@ a.new-post-btn {
   100% {
     -webkit-transform: scale(0.2);
     opacity: 0.1; } }
+
 @-moz-keyframes togglePulsar {
   0% {
     -moz-transform: scale(0.2);
@@ -4767,6 +4768,7 @@ a.new-post-btn {
   100% {
     -moz-transform: scale(0.2);
     opacity: 0.1; } }
+
 @keyframes togglePulsar {
   0% {
     -webkit-transform: scale(0.2);
@@ -4811,6 +4813,7 @@ a.new-post-btn {
       width: 3.06rem; }
   .a--header-design-02 button.a--site-nav__mobile-toggle.a--toggled .a--toggle-pulsar {
     display: none; }
+
 .a--header-design-02 ul.a--slide-menu__container li {
   display: block; }
   .a--header-design-02 ul.a--slide-menu__container li a {
@@ -4833,6 +4836,7 @@ a.new-post-btn {
     width: 5rem;
     height: 0.2rem;
     background-color: rgba(255, 255, 255, 0.4); }
+
 .a--header-design-02 .a--slide-menu__container, .a--header-design-02 ul.a--slide-menu__container {
   position: absolute;
   z-index: 1001;
@@ -5160,6 +5164,7 @@ a.new-post-btn {
   @media (max-width: 767px) {
     .a--course-tile-01__wrapper {
       width: 100%; } }
+
 .a--course-tile-01__container {
   border: 0.1rem solid #dedede;
   padding: 0;
@@ -5190,6 +5195,7 @@ a.new-post-btn {
     -webkit-box-shadow: 0 1.9rem 3.8rem rgba(0, 0, 0, 0.3), 0 1.5rem 1.2rem rgba(0, 0, 0, 0.22);
     -moz-box-shadow: 0 1.9rem 3.8rem rgba(0, 0, 0, 0.3), 0 1.5rem 1.2rem rgba(0, 0, 0, 0.22);
     box-shadow: 0 1.9rem 3.8rem rgba(0, 0, 0, 0.3), 0 1.5rem 1.2rem rgba(0, 0, 0, 0.22); }
+
 .a--course-tile-01__image {
   width: 100%;
   height: 18rem;
@@ -5200,6 +5206,7 @@ a.new-post-btn {
   flex-grow: 0;
   -ms-flex-positive: 0;
   border-bottom: 0.4rem solid #3da794; }
+
 .a--course-tile-01__info {
   padding: 3rem 2rem;
   display: -webkit-box;
@@ -5230,6 +5237,7 @@ a.new-post-btn {
   justify-content: space-between;
   -ms-flex-pack: justify;
   background-color: #fff; }
+
 .a--course-tile-01__code, .a--course-tile-01__organization {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5237,6 +5245,7 @@ a.new-post-btn {
   font-size: 1.4rem;
   color: rgba(31, 31, 31, 0.8);
   margin: 0 0 0.5rem; }
+
 .a--course-tile-01__title {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5245,10 +5254,12 @@ a.new-post-btn {
   margin: 0 0 1.5rem;
   color: #3da794;
   display: block; }
+
 .a--course-tile-01__organization {
   border-top: 0.1rem solid rgba(31, 31, 31, 0.1);
   padding-top: 1.5rem;
   display: block; }
+
 .a--course-tile-01__start-date {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5361,6 +5372,7 @@ a.new-post-btn {
   @media (max-width: 767px) {
     .a--course-tile-02__wrapper {
       width: 100%; } }
+
 .a--course-tile-02__container {
   border: 0.1rem solid #dedede;
   padding: 0;
@@ -5377,6 +5389,7 @@ a.new-post-btn {
     -webkit-box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
     -moz-box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
     box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22); }
+
 .a--course-tile-02__image {
   -webkit-flex-shrink: 0;
   -moz-flex-shrink: 0;
@@ -5409,8 +5422,10 @@ a.new-post-btn {
       height: 140px;
       bottom: -28px;
       right: -20px; } }
+
 .a--course-tile-02__info {
   padding: 3rem 2rem; }
+
 .a--course-tile-02__code, .a--course-tile-02__organization {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5418,6 +5433,7 @@ a.new-post-btn {
   font-size: 1.4rem;
   color: rgba(31, 31, 31, 0.8);
   margin: 0 0 0.5rem; }
+
 .a--course-tile-02__title {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5429,6 +5445,7 @@ a.new-post-btn {
   color: #3da794;
   display: block;
   border-bottom: 0.1rem solid rgba(31, 31, 31, 0.2); }
+
 .a--course-tile-02__start-date {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -5715,9 +5732,11 @@ a.new-post-btn {
       max-width: 100%; }
     .a--course-listing-01__container.centered .a--course-tile-03 {
       margin: 1rem auto; }
+
 .a--course-listing-01__header {
   margin-bottom: 5rem;
   max-width: 78rem; }
+
 .a--course-listing-01__section-heading {
   font-family: 'Lato', sans-serif;
   font-weight: 300;
@@ -5727,6 +5746,7 @@ a.new-post-btn {
   color: #3da794;
   text-transform: none;
   text-align: inherit; }
+
 .a--course-listing-01__courses {
   display: -webkit-box;
   display: -moz-box;
@@ -6263,6 +6283,7 @@ li.courses-listing-item {
     font-family: "Open Sans", sans-serif;
     font-style: normal;
     font-weight: 700; }
+
 .a--dashboard__content .search-result-list {
   margin: 2rem 0 0;
   padding: 0; }
@@ -6291,6 +6312,7 @@ li.courses-listing-item {
       margin-left: 1rem;
       display: inline-block;
       color: rgba(31, 31, 31, 0.5); }
+
 .a--dashboard__content .search-load-next {
   display: inline-block;
   padding: 1rem 1.5rem;
@@ -6310,6 +6332,7 @@ li.courses-listing-item {
   padding-bottom: 1rem;
   margin: 1rem auto 2rem;
   position: relative; }
+
 .a--courseware-top-nav__mobile-scroll-indicator {
   width: 7rem;
   position: absolute;
@@ -6348,6 +6371,7 @@ li.courses-listing-item {
     -o-justify-content: space-around;
     justify-content: space-around;
     -ms-flex-pack: distribute; }
+
 .a--courseware-top-nav__list-container {
   overflow-y: auto;
   position: relative; }
@@ -6360,6 +6384,7 @@ li.courses-listing-item {
     .a--courseware-top-nav__list-container.a--animated.a--do-animate {
       opacity: 1;
       top: 0; }
+
 .a--courseware-top-nav__list {
   padding: 0;
   margin: 0;
@@ -6379,6 +6404,7 @@ li.courses-listing-item {
   -o-align-items: center;
   align-items: center;
   -ms-flex-align: center; }
+
 .a--courseware-top-nav__item {
   list-style-type: none;
   display: inline-block;
@@ -6417,6 +6443,7 @@ li.courses-listing-item {
       border-radius: 0.5rem; }
       .a--courseware-top-nav__item a.active:hover, .a--courseware-top-nav__item a.active:focus {
         top: 0; }
+
 .a--courseware-top-nav__preview-menu-wrapper {
   padding: 2rem !important;
   background-color: #225c52;
@@ -6431,12 +6458,14 @@ li.courses-listing-item {
 .a--courseware-banner__wrapper {
   padding: 2rem;
   background-color: #dedede; }
+
 .a--courseware-banner__container h2 {
   font-size: 2rem;
   font-family: "Open Sans", sans-serif;
   font-style: normal;
   font-weight: 700;
   margin: 0.5rem 0 1rem; }
+
 .a--courseware-banner__container p {
   margin: 0.5rem 0; }
   .a--courseware-banner__container p a {
@@ -6540,6 +6569,7 @@ li.courses-listing-item {
   font-size: 3.2rem;
   color: #3da794;
   margin: 0 0 2.5rem; }
+
 .a--course-info > ol {
   padding: 0; }
   .a--course-info > ol li {
@@ -6734,6 +6764,7 @@ li.courses-listing-item {
       font-style: italic;
       font-weight: 400;
       color: rgba(31, 31, 31, 0.7); }
+
 .a--course-content__main-content {
   width: 100%;
   min-width: 0;
@@ -7173,8 +7204,10 @@ div.book-wrapper {
   font-weight: 400;
   font-size: 1.6rem;
   line-height: 1.65eem !important; }
+
 .a--course-static-page h1, .a--course-static-page h2, .a--course-static-page h3, .xmodule_display.xmodule_StaticTabModule h1, .xmodule_display.xmodule_StaticTabModule h2, .xmodule_display.xmodule_StaticTabModule h3 {
   text-transform: none; }
+
 .a--course-static-page h1, .xmodule_display.xmodule_StaticTabModule h1 {
   text-transform: none;
   font-family: "Open Sans", sans-serif;
@@ -7183,6 +7216,7 @@ div.book-wrapper {
   font-size: 38.4px;
   color: #3da794;
   letter-spacing: 0; }
+
 .a--course-static-page h2, .xmodule_display.xmodule_StaticTabModule h2 {
   text-transform: none;
   font-family: "Open Sans", sans-serif;
@@ -7191,6 +7225,7 @@ div.book-wrapper {
   font-size: 28.8px;
   color: #3da794;
   letter-spacing: 0; }
+
 .a--course-static-page h3, .xmodule_display.xmodule_StaticTabModule h3 {
   text-transform: none;
   font-family: 'Lato', sans-serif;
@@ -7198,6 +7233,7 @@ div.book-wrapper {
   text-transform: uppercase;
   color: #3da794;
   letter-spacing: 0; }
+
 .a--course-static-page h4, .xmodule_display.xmodule_StaticTabModule h4 {
   text-transform: none;
   font-family: 'Lato', sans-serif;
@@ -7205,6 +7241,7 @@ div.book-wrapper {
   text-transform: uppercase;
   color: rgba(31, 31, 31, 0.75);
   letter-spacing: 0; }
+
 .a--course-static-page ul li, .a--course-static-page ol li, .a--course-static-page .xmodule_display.xmodule_CapaModule div.problem p, .xmodule_display.xmodule_StaticTabModule ul li, .xmodule_display.xmodule_StaticTabModule ol li, .xmodule_display.xmodule_StaticTabModule .xmodule_display.xmodule_CapaModule div.problem p {
   font-size: 16px; }
 
@@ -7338,8 +7375,10 @@ div.book-wrapper {
     font-size: 1.8rem;
     color: #fff;
     margin: -1rem 0 3rem; }
+
 .a--course-about-01__courseware-button-wrapper #register_error {
   display: inline-block; }
+
 .a--course-about-01__social-share {
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
@@ -7392,6 +7431,7 @@ div.book-wrapper {
     opacity: 0.7; }
     .a--course-about-01__social-share a:hover, .a--course-about-01__social-share a:focus {
       opacity: 1; }
+
 .a--course-about-01__courseware-btn {
   background-color: #f6322b;
   border: none;
@@ -7423,6 +7463,7 @@ div.book-wrapper {
     color: #fff; }
   .a--course-about-01__courseware-btn:hover, .a--course-about-01__courseware-btn:focus {
     color: rgba(255, 255, 255, 0.8); }
+
 .a--course-about-01__overview {
   padding: 3rem 0 5rem;
   background-color: transparent;
@@ -7459,6 +7500,7 @@ div.book-wrapper {
     margin-top: 3rem; }
     .a--course-about-01__overview .teacher .teacher-image img {
       float: none; }
+
 .a--course-about-01__info {
   display: block;
   width: 30%;
@@ -7509,6 +7551,7 @@ div.book-wrapper {
       font-style: normal;
       font-weight: 400;
       display: inline-block; }
+
 .a--course-about-01__content {
   padding-bottom: 4rem; }
   @media (min-width: 992px) {
@@ -7886,6 +7929,7 @@ div.book-wrapper {
       opacity: 0.85; }
   .account-settings-sections .section .u-field-message-help {
     color: #1f1f1f; }
+
 .account-settings-sections .section-header {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -7894,6 +7938,7 @@ div.book-wrapper {
   color: rgba(31, 31, 31, 0.7);
   margin-bottom: 10px;
   padding-bottom: 20px; }
+
 .account-settings-sections a, .account-settings-sections a span {
   color: #3da794;
   -webkit-transition: all 0.3s ease-in-out;
@@ -7903,6 +7948,7 @@ div.book-wrapper {
 
 .view-profile .wrapper-profile {
   width: 100%; }
+
 .view-profile .profile-self .wrapper-profile-field-account-privacy {
   background-color: rgba(31, 31, 31, 0.2);
   padding-top: 20px;
@@ -7940,6 +7986,7 @@ div.book-wrapper {
       border-bottom: 1px solid rgba(31, 31, 31, 0.6); }
       .view-profile .profile-self .wrapper-profile-field-account-privacy .u-field-value select:focus {
         outline: none; }
+
 .view-profile .wrapper-profile-sections {
   display: -webkit-box;
   display: -moz-box;
@@ -7957,6 +8004,7 @@ div.book-wrapper {
   flex-wrap: wrap;
   padding: 30px;
   min-width: 0; }
+
 .view-profile .wrapper-profile-section-one {
   display: -webkit-box;
   display: -moz-box;
@@ -7984,6 +8032,7 @@ div.book-wrapper {
       padding: 0 0 20px 0;
       border: none;
       border-bottom: 1px solid rgba(31, 31, 31, 0.2); } }
+
 .view-profile .wrapper-profile-section-two {
   width: 60%;
   padding-left: 20px; }
@@ -7991,11 +8040,13 @@ div.book-wrapper {
     .view-profile .wrapper-profile-section-two {
       width: 100%;
       padding: 20px 0 0 0; } }
+
 .view-profile .profile-image-field {
   -webkit-flex-shrink: 0;
   -moz-flex-shrink: 0;
   flex-shrink: 0;
   -ms-flex-negative: 0; }
+
 .view-profile .profile-section-one-fields {
   -webkit-flex-grow: 1;
   -moz-flex-grow: 1;
@@ -8016,20 +8067,24 @@ div.book-wrapper {
     top: -3px;
     right: 3px;
     color: #3da794 !important; }
+
 .view-profile .profile-section-two-fields .u-field-title {
   width: 80%;
   color: #3da794; }
+
 .view-profile .profile-section-two-fields .editable-toggle {
   padding: 5px;
   -webkit-transition: all 0.2s ease-in-out;
   transition: all 0.2s ease-in-out; }
   .view-profile .profile-section-two-fields .editable-toggle:hover, .view-profile .profile-section-two-fields .editable-toggle:focus {
     background-color: rgba(61, 167, 148, 0.05); }
+
 .view-profile .profile-section-two-fields .message-can-edit {
   position: relative;
   top: -3px;
   right: 3px;
   color: #3da794 !important; }
+
 .view-profile input {
   font-family: "Open Sans", sans-serif;
   font-style: normal;
@@ -8187,6 +8242,7 @@ span#djangopid, span#edxver {
     border-bottom: 0.1rem solid rgba(31, 31, 31, 0.2); }
     .a--dashboard-01__notifications__notification:last-child {
       border-bottom: none; }
+
 .a--dashboard-01__main__container {
   display: -webkit-box;
   display: -moz-box;
@@ -8204,6 +8260,7 @@ span#djangopid, span#edxver {
       -moz-flex-wrap: wrap;
       -ms-flex-wrap: wrap;
       flex-wrap: wrap; } }
+
 .a--dashboard-01__main__content {
   -webkit-flex-shrink: 1;
   -moz-flex-shrink: 1;
@@ -8212,8 +8269,10 @@ span#djangopid, span#edxver {
   width: 100%;
   max-width: 98rem;
   margin: 0 auto; }
+
 .a--dashboard-01__main__search-results {
   padding: 0 0 4rem; }
+
 .a--dashboard-01__main__sidebar {
   -webkit-flex-shrink: 0;
   -moz-flex-shrink: 0;
@@ -8229,8 +8288,10 @@ span#djangopid, span#edxver {
       margin-top: 4rem;
       padding-top: 4rem;
       border-top: 0.1rem solid rgba(31, 31, 31, 0.3); } }
+
 .a--dashboard-01__main__courses {
   padding: 0 0 4rem; }
+
 .a--dashboard-01__promote-catalog {
   padding: 3rem 0;
   border-bottom: 0.1rem solid rgba(31, 31, 31, 0.3);
@@ -8569,8 +8630,10 @@ span#djangopid, span#edxver {
     font-size: 1.8rem;
     color: #fff;
     margin: -1rem 0 3rem; }
+
 .a--course-about-palix__courseware-button-wrapper #register_error {
   display: inline-block; }
+
 .a--course-about-palix__social-share {
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
@@ -8624,6 +8687,7 @@ span#djangopid, span#edxver {
     .a--course-about-palix__social-share a:hover, .a--course-about-palix__social-share a:focus {
       color: #fff;
       opacity: 0.7; }
+
 .a--course-about-palix__courseware-btn {
   border: none;
   display: inline-block;
@@ -8657,6 +8721,7 @@ span#djangopid, span#edxver {
   .a--course-about-palix__courseware-btn:hover, .a--course-about-palix__courseware-btn:focus {
     color: #3da794;
     opacity: 0.75; }
+
 .a--course-about-palix__overview {
   padding: 3rem 0 5rem;
   background-color: transparent;
@@ -8712,6 +8777,7 @@ span#djangopid, span#edxver {
     color: #3da794;
     text-transform: uppercase;
     font-size: 2.4rem; }
+
 .a--course-about-palix__info {
   display: block;
   width: 30%;
@@ -8762,6 +8828,7 @@ span#djangopid, span#edxver {
       font-style: normal;
       font-weight: 700;
       display: inline-block; }
+
 .a--course-about-palix__content {
   padding-bottom: 4rem; }
   @media (min-width: 992px) {
@@ -8773,6 +8840,7 @@ span#djangopid, span#edxver {
       display: -moz-flex;
       display: -ms-flexbox;
       display: flex; } }
+
 .a--course-about-palix article.response {
   padding-bottom: 2rem;
   margin-bottom: 2rem;
@@ -8806,7 +8874,7 @@ span#djangopid, span#edxver {
   .a--heading-plus-text-plus-cta.negative .a--cta {
     background-color: #fff;
     color: #3da794; }
-    .a--heading-plus-text-plus-cta.negative .a--cta:hover, .a--heading-plus-text-plus-cta.negative .a--cta:focus  {
+    .a--heading-plus-text-plus-cta.negative .a--cta:hover, .a--heading-plus-text-plus-cta.negative .a--cta:focus  {
       background-color: #fff;
       color: #3da794 !important;
       opacity: 0.7; }
@@ -8824,6 +8892,7 @@ span#djangopid, span#edxver {
   @media (max-width: 767px) {
     .a--course-listing-01__section-heading {
       font-size: 2.4rem; } }
+
 .a--course-listing-01__section-text {
   max-width: 92rem;
   margin: 0 auto;
@@ -8881,6 +8950,7 @@ span#djangopid, span#edxver {
       -moz-flex-wrap: wrap;
       -ms-flex-wrap: wrap;
       flex-wrap: wrap; } }
+
 .palix--index-what-learn__graphic {
   width: 24rem;
   margin-right: 6rem;
@@ -8900,6 +8970,7 @@ span#djangopid, span#edxver {
     display: block;
     width: 100%;
     max-width: 24rem; }
+
 .palix--index-what-learn__content {
   width: 100%;
   -webkit-flex-shrink: 1;
@@ -8910,5 +8981,3 @@ span#djangopid, span#edxver {
   -moz-flex-grow: 1;
   flex-grow: 1;
   -ms-flex-positive: 1; }
-
-/*# sourceMappingURL=main.css.map */

--- a/templates/courseware/course_about.html
+++ b/templates/courseware/course_about.html
@@ -113,7 +113,7 @@ from openedx.core.lib.courses import course_image_url
 
   ## Translators: This text will be automatically posted to the student's
   ## Twitter account. {url} should appear at the end of the text.
-  tweet_text = _("I just enrolled in {number} {title} through {account}: {url}").format(
+  tweet_text = _("I just enrolled in a brain science course from the Alberta Family Wellness Initiative. It's free: {url}").format(
     number=course.number,
     title=course.display_name_with_default,
     account=microsite.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
@@ -128,7 +128,7 @@ from openedx.core.lib.courses import course_image_url
 
   email_subject = u"mailto:?subject={subject}&body={body}".format(
     subject=_("Take a course with {platform} online").format(platform=platform_name),
-    body=_("I just enrolled in {number} {title} through {platform} {url}").format(
+    body=_("I have just enrolled in the online course &quot;Brain Story Certification&quot; by the Alberta Family Wellness Initiative. This free course is open to everyone and I thought you might be interested in enrolling too. Visit the Alberta Family Wellness Initiative for course details. {number} {title} through {platform} {url}").format(
     number=course.number,
     title=course.display_name_with_default,
     platform=platform_name,


### PR DESCRIPTION
This PR [addresses the following Trello card](https://trello.com/c/4lZrcpPN/644-palix-adjust-social-media-sharing-icon-content) where the client has asked for social media message edits that are generated from icons on the course about pages. This base message does not exist in Appsembler design templates and had to be changed directly in `course_about.html`

The existing code is not written to generate a custom Facebook message as requested by the client, which just leaves Twitter and email. 

I tried to take `main.css` out of this to keep a clean Git log but had no luck with this. The changes seemed minor enough to not cause impact and I saw no issues in testing.

cc @grozdanowski @abeals 