### PR TITLE
Homepage copy updates, and changing where we pull GitHub content from

### DIFF
--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -91,7 +91,7 @@
         <%include file='../jobs/find_jobs.html' />
 
         ## include sidebar content from git repo
-        ${_(urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/upcoming-courses.html').read())}
+        ${_(urllib2.urlopen('https://gymnasium.github.io/static-site-content/upcoming-courses.html').read())}
       </div>
     </div> 
   </main>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -128,7 +128,7 @@ import urllib2
         <section class="my-courses col-md-9" id="my-courses">
 
           <div class="dashboard-custom-content">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/dashboard.html').read() | n}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/dashboard.html').read() | n}
           </div>
 
           <header class="hero">

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -48,7 +48,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
         <div class="col-md-4 col-sm-12 col-xs-12">
           <h2>Free Online Courses</h2>
           <p>
-            We offer free online courses designed to empower creative professionals with marketable skills.
+            We offer free online courses designed to empower creative professionals.
           </p>
         </div>
 

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -36,7 +36,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
 
 
 <section class="home">
-  ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/home/hero.html').read()}
+  ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/home/hero.html').read()}
 
   <section class="container-fluid subsection">
     <div class="container">
@@ -69,7 +69,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
           </header>
 
           <section class="courses row">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/home/featured-courses.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/home/featured-courses.html').read()}
           </section>
         </section>
 

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -46,18 +46,24 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
 
       <section class="row how-gymnasium-works">
         <div class="col-md-4 col-sm-12 col-xs-12">
-          <h2>Real World Skills</h2>
-          <p>Gymnasium offers free online courses designed to teach creative professionals in-demand skills.  We know these skills are in demand based on what we hear from our clients.</p>
+          <h2>Free Online Courses</h2>
+          <p>
+            We offer free online courses designed to empower creative professionals with marketable skills.
+          </p>
         </div>
 
         <div class="col-md-4 col-sm-12 col-xs-12">
           <h2>Expert Instruction</h2>
-          <p>Our courses are all self-paced and taught by experienced practitioners with a passion for sharing practical lessons from the design trenches.</p>
+          <p>
+            Our courses are taught by industry experts and trailblazers in the web community.
+          </p>
         </div>
 
         <div class="col-md-4 col-sm-12 col-xs-12">
           <h2>Career Opportunities</h2>
-          <p>Once you finish a course, you will be able to use your new skills in your current role, or use them to land a new job. <a href="http://aquent.com/find-work/?utm_source=gymnasium&utm_medium=web&utm_campaign=homepagejobs&utm_content=careeropportunities" target="_blank">We can even help with that!</a></p>
+          <p>
+              You can learn new skills at your own speed and even use those skills to <a href="http://aquent.com/find-work/?utm_source=gymnasium&utm_medium=web&utm_campaign=homepagejobs&utm_content=careeropportunities" target="_blank">land a new job</a>.
+          </p>
         </div>
       </section>
 

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -244,7 +244,7 @@
 
       </div>
       <div class="col-md-3 additional-information">
-        ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/login-sidebar.html').read()}
+        ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/login-sidebar.html').read()}
       </div>
     </div>
   </div>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -149,9 +149,9 @@ site_status_msg = get_site_status_msg(course_id)
   </header>
 
   % if settings.PLATFORM_NAME == "Gymnasium STAGING":
-    ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/system_status/staging.html').read()}
+    ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/system_status/staging.html').read()}
   % else:
-    ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/system_status/production.html').read()}
+    ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/system_status/production.html').read()}
   % endif
 
 % if course:

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -171,7 +171,7 @@ import urllib2
       </div>
       
       <div class="col-md-3 additional-information">
-        ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/register-sidebar.html').read()}
+        ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/register-sidebar.html').read()}
       </div>
     </div>
   </div>

--- a/lms/templates/static_templates/about.html
+++ b/lms/templates/static_templates/about.html
@@ -28,7 +28,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/about.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/about.html').read()}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/careers.html
+++ b/lms/templates/static_templates/careers.html
@@ -9,7 +9,7 @@
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/careers.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/careers.html').read()}
           </div>
           <div class="col-md-3">
             <%include file="theme-upcoming-content.html" />

--- a/lms/templates/static_templates/faq.html
+++ b/lms/templates/static_templates/faq.html
@@ -9,7 +9,7 @@
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/faq.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/faq.html').read()}
           </div>
           <div class="col-md-3">
             <%include file="theme-upcoming-content.html" />

--- a/lms/templates/static_templates/honor.html
+++ b/lms/templates/static_templates/honor.html
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include privacy policy from git repo
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/privacy-policy.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/privacy-policy.html').read()}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/jobs.html
+++ b/lms/templates/static_templates/jobs.html
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include jobs page from git repo
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/jobs.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/jobs.html').read()}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/privacy.html
+++ b/lms/templates/static_templates/privacy.html
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include privacy policy from git repo
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/privacy-policy.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/privacy-policy.html').read()}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/support.html
+++ b/lms/templates/static_templates/support.html
@@ -9,7 +9,7 @@
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/support.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/support.html').read()}
           </div>
           <div class="col-md-3">
             <%include file="theme-upcoming-content.html" />

--- a/lms/templates/static_templates/theme-upcoming-content.html
+++ b/lms/templates/static_templates/theme-upcoming-content.html
@@ -1,2 +1,2 @@
 <% import urllib2 %>
-${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/static-pages-sidebar-content.html').read()}
+${urllib2.urlopen('https://gymnasium.github.io/static-site-content/static-pages-sidebar-content.html').read()}

--- a/lms/templates/static_templates/tos.html
+++ b/lms/templates/static_templates/tos.html
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include privacy policy from git repo
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/privacy-policy.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/privacy-policy.html').read()}
           </div>
 
           <div class="col-md-3">


### PR DESCRIPTION
# This PR Contains
- Updates to the copy on the "How Gymnasium Works" section on the home page
- Content from our GitHub Pages pseudo-CMS are now pulled from a technically-more-correct URL, for better bulletproofing.  This functionality is visible on various parts of the home page, and all static content pages (linked in footer, for the most part.)