### PR TITLE
Release: More prep for badging

### DIFF
--- a/lms/static/sass/_gymnasium.scss
+++ b/lms/static/sass/_gymnasium.scss
@@ -334,6 +334,12 @@ body.register,
 	a:link:visited,
 	a:active,
 	a:link:active,
+	p a,
+	p a:link,
+	p a:visited,
+	a.gymlink,
+	a.gymlink:link,
+	a.gymlink:visited
 	{		
 		color: $gym-orange;
 		font-family:$theme-serif-font;
@@ -352,7 +358,10 @@ body.register,
 	.dashboard .my-courses .course .info>hgroup h3 span:hover,
 	.dashboard .my-courses .course .info>hgroup h3 span:focus,
 	p a:link:hover,
-	p a:hover
+	p a:hover,
+	a.gymlink:hover,
+	a.gymlink:link:hover,
+	a.gymlink:visited:hover
 	{
 		border-bottom:1px solid $gym-orange;
 		color:$gym-orange;

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -80,7 +80,7 @@
             Gym Shorts
           </h1>
           <p class="hero">
-            Gym Shorts are short courses that all last under an hour. Like our full courses, they are taught by industry experts and focus on current skills and technologies. Each includes approximately one hour of video instruction, a final exam, and a badge (if and) when you pass.
+            Gym Shorts are short courses that all last under an hour. Like our Full Courses, they are taught by industry experts and focus on current skills and technologies. Each includes approximately one hour of video instruction, a final exam, and a badge (if and) when you pass.
           </p>
           <ul class="listing-courses" id="gym-shorts-list">
 

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -80,7 +80,7 @@
             Gym Shorts
           </h1>
           <p class="hero">
-            Gym Shorts are short, snackable courses that all last under an hour. Like our longer courses, they are practical, taught by experienced practitioners, and focused on in-demand skills and technologies.
+            Gym Shorts are short courses that all last under an hour. Like our full courses, they are taught by industry experts and focus on current skills and technologies. Each includes approximately one hour of video instruction, a final exam, and a badge (if and) when you pass.
           </p>
           <ul class="listing-courses" id="gym-shorts-list">
 

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -14,7 +14,7 @@ from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%
-  cert_name_short = settings.CERT_NAME_SHORT
+  cert_name_short = "certificate"
   cert_name_long = settings.CERT_NAME_LONG
 %>
 

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -71,7 +71,7 @@ else:
   <ul class="actions actions-secondary">
       <li class="action action-share">
         <a class="action-linkedin-profile" target="_blank" href="${cert_status['linked_in_url']}"
-         title="${_('Add Certificate to LinkedIn Profile')}"
+         title="${_('Add certificate to LinkedIn Profile')}"
          data-course-id="${course_overview.id}"
          data-certificate-mode="${cert_status['mode']}"
         >

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -127,7 +127,7 @@ from student.helpers import (
               <li class="action action-certificate">
               <a href="${cert_status['download_url']}"
                 title="${_('View your ')}${credential_type}">
-                ${_("My {cert_name_short}").format(cert_name_short=cert_name_short)}</a></li>
+                ${_("My {cert_name_short}").format(cert_name_short=credential_type)}</a></li>
             </li>
           % endif
           

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -34,6 +34,12 @@ from student.helpers import (
 
 <%namespace name='static' file='../static_content.html'/>
 
+% if int(course_overview.display_number_with_default) >= 100:
+  <% credential_type="certificate" %>
+% else: 
+  <% credential_type="badge" %>
+% endif
+
 <li class="course-item">
   % if settings.FEATURES.get('ENABLE_VERIFIED_CERTIFICATES'):
     % if enrollment.mode == "verified":
@@ -115,7 +121,7 @@ from student.helpers import (
             <li>
               <li class="action action-certificate">
               <a href="${cert_status['download_url']}"
-                title="${_('View your certificate')}">
+                title="${_('View your ')}${credential_type}">
                 ${_("My {cert_name_short}").format(cert_name_short=cert_name_short)}</a></li>
             </li>
           % endif

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -115,7 +115,7 @@ from student.helpers import (
             <li>
               <li class="action action-certificate">
               <a href="${cert_status['download_url']}"
-                title="${_('This link will open/download a PDF document')}">
+                title="${_('View your certificate')}">
                 ${_("My {cert_name_short}").format(cert_name_short=cert_name_short)}</a></li>
             </li>
           % endif

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -34,11 +34,16 @@ from student.helpers import (
 
 <%namespace name='static' file='../static_content.html'/>
 
-% if int(course_overview.display_number_with_default) >= 100:
-  <% credential_type="certificate" %>
-% else: 
-  <% credential_type="badge" %>
-% endif
+<% 
+  try: 
+    if int(course_overview.display_number_with_default) >= 100:
+      credential_type="certificate"
+    else: 
+      credential_type="badge"
+    endif
+  except ValueError:
+    credential_type="certificate"
+%>
 
 <li class="course-item">
   % if settings.FEATURES.get('ENABLE_VERIFIED_CERTIFICATES'):

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -18,7 +18,7 @@ from openedx.core.djangolib.markup import HTML
       <h2>Congratulations!</h2>
       <p>Congratulations on completing the course and passing the final exam with flying colors. You really know your stuff!</p>
 
-      <p>Show off to your friends and colleagues by downloading your Certificate of Excellence from your <a href="/dashboard">Dashboard</a>.</p>
+      <p>Show off to your network by sharing your badge on LinkedIn. You can download it right from your <a href="/dashboard">Dashboard</a>.</p>
 
 
       <div class="survey">

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -16,9 +16,9 @@ from openedx.core.djangolib.markup import HTML
     <div class="col-md-12">
       <br />
       <h2>Congratulations!</h2>
-      <p>Congratulations on completing the course and passing the final exam with flying colors. You really know your stuff!</p>
+      <p>Congrats on completing the course and passing the final exam. You really know your stuff!</p>
 
-      <p>Show off to your network by sharing your badge on LinkedIn. You can download it right from your <a class="gymlink" href="/dashboard">Dashboard</a>.</p>
+      <p>Now show off to your network by sharing your badge on LinkedIn. You can access it right from your <a class="gymlink" href="/dashboard">Dashboard</a>.</p>
 
 
       <div class="survey">

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -22,7 +22,7 @@ from openedx.core.djangolib.markup import HTML
 
 
       <div class="survey">
-        <p>Before you head on to your next achievement, could you please take a moment to share your thoughts with us on a quick survey? Your feedback will help shape our future course offerings and let us know how <b>we’re</b> doing.</p>
+        <p>Before you head on to your next achievement, could you please take a moment to share your thoughts with us on a quick survey? Your feedback will help shape our future course offerings and let us know how <em>we’re</em> doing.</p>
       </div>
     </div>
   </div>

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -11,6 +11,8 @@ from openedx.core.djangolib.markup import HTML
 </h2>
 <div class="problem-progress"></div>
 
+${gymcms.render('final-exam-modal-top')}
+
 <div class="problem" aria-relevant="all">
   <div aria-live="polite">
     ${ HTML(problem['html']) }

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -2,70 +2,14 @@
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML
-
 %>
 
+<%namespace name="gymcms" file="./util/gymcms.mako" />
 <%namespace name='static' file='static_content.html'/>
 <h2 class="hd hd-2 problem-header">
   ${ problem['name'] }
 </h2>
 <div class="problem-progress"></div>
-
-<div class="passed_modal hidden final-exam-status" aria-hidden="true" id="course_passed_message">
-  <div class="row">
-    <div class="col-md-12">
-      <br />
-      <h2>Congratulations!</h2>
-      <p>Congrats on completing the course and passing the final exam. You really know your stuff!</p>
-
-      <p>Now show off to your network by sharing your badge on LinkedIn. You can access it right from your <a class="gymlink" href="/dashboard">Dashboard</a>.</p>
-
-
-      <div class="survey">
-        <p>Before you head on to your next achievement, could you please take a moment to share your thoughts with us on a quick survey? Your feedback will help shape our future courses and let us know how <em>we’re</em> doing.</p>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <a class="gym-button text-center col-md-2 col-md-offset-5" href="https://www.surveymonkey.com/s/JYJPMSS" target="_blank">
-      Take Our Survey
-    </a>
-  </div>
-</div>
-
-<div class="try_again_modal hidden final-exam-status" aria-hidden"true">
-  <div class="row">
-    <div class="col-md-12">
-      <br />
-      <h2>YOU'RE CLOSE!</h2>
-      <p>We're thrilled you’ve made it this far. You’ve scored a <span class="exam-score-container"></span> on the exam. To pass you need to get greater than an 85.</p>
-
-      <p>Lucky for you, you've still got one more chance to pass. This would be a great time to go back and review the course material. Take a look at things you may have struggled with and have another go when you feel prepared. </p>
-
-      <p>Good luck!</p>
-
-    </div>
-  </div>
-</div>
-
-<div class="failed_modal hidden final-exam-status" aria-hidden="true">
-  <div class="row">
-    <div class="col-md-12">
-      <br />
-      <h2>AW, SHUCKS.</h2>
-      <p>Don’t worry, you deserve a lot of credit for finishing the course! Only 1 in 10 students who takes an online course like this actually ever finishes, so your commitment puts you in an elite crowd.</p>
-
-      <div class="survey">
-        <p>We’re thrilled you’ve joined us and would love your feedback to make our courses even better. If you could take a moment to share your thoughts with us on a quick survey, it would help shape our future offerings.</p>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <a class="gym-button text-center col-md-2 col-md-offset-5" href="https://www.surveymonkey.com/s/JYJPMSS" target="_blank">
-      Take Our Survey
-    </a>
-  </div>
-</div>
 
 <div class="problem" aria-relevant="all">
   <div aria-live="polite">
@@ -78,7 +22,7 @@ from openedx.core.djangolib.markup import HTML
     <div class="problem-hint" aria-live="polite"></div>
     % endif
     % if check_button:
-    <button class="gym-button natural check ${ check_button }" data-checking="${ check_button_checking }" data-value="${ check_button }"><span class="check-label">${ check_button }</span><span class="sr"> ${_("your answer")}</span></button>
+    <button class="gym-button natural check ${ check_button }" id="chec-button" data-checking="${ check_button_checking }" data-value="${ check_button }"><span class="check-label">${ check_button }</span><span class="sr"> ${_("your answer")}</span></button>
     % endif
     % if demand_hint_possible:
     <button class="gym-button natural hint-button" data-value="${_('Hint')}">${_('Hint')}</button>
@@ -102,6 +46,8 @@ from openedx.core.djangolib.markup import HTML
     % endif
   </div>
 </div>
+
+${gymcms.render('final-exam-modal')}
 
 <script>
   $(function(){
@@ -131,6 +77,14 @@ from openedx.core.djangolib.markup import HTML
         show_problem_progress();
       }
     }
+  
+    function scrollToResultsMessage() {
+      $('#course_passed_message')[0].scrollIntoView();
+    }
+
+    $('#check-button').click(function() {
+      scrollToResultsMessage();
+    });
 
     var show_problem_progress = function(){
 
@@ -157,22 +111,19 @@ from openedx.core.djangolib.markup import HTML
 
       var passing_score = 85;
 
-      if (progress_string.length > 0)
-      {
+      if (progress_string.length > 0) {
         //Gymnasium.RecordExamGrade =  function(email, courseId, grade, callback)
         % if (user.is_authenticated()):
           var email = "${user.email}";
           var courseID = $('#__course_number__').text();
           
-          if (email && courseID && score)
-          {
+          if (email && courseID && score) {
             // Gymnasium.RecordExamGrade(email, courseID, score);
           }
         %endif
 
         //we have a score
-        if (score >= passing_score)
-        {
+        if (score >= passing_score) {
           //we passed! show passing div
           $(".passed_modal").removeClass('hidden');
           $(".try_again_modal").addClass('hidden');
@@ -186,19 +137,13 @@ from openedx.core.djangolib.markup import HTML
             success:  function(data) {
             }
           });
-
-        }
-        else
-        {
+        } else {
           //we failed :( see if we have another attempt
-          if (attempts_remaining > 0)
-          {
+          if (attempts_remaining > 0) {
             $(".passed_modal").addClass('hidden');
             $(".try_again_modal").removeClass('hidden');
             $(".failed_modal").addClass('hidden');
-          }
-          else
-          {
+          } else {
             $(".passed_modal").addClass('hidden');
             $(".try_again_modal").addClass('hidden');
             $(".failed_modal").removeClass('hidden');

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -22,7 +22,7 @@ from openedx.core.djangolib.markup import HTML
 
 
       <div class="survey">
-        <p>Before you head on to your next achievement, could you please take a moment to share your thoughts with us on a quick survey? Your feedback will help shape our future course offerings and let us know how <em>we’re</em> doing.</p>
+        <p>Before you head on to your next achievement, could you please take a moment to share your thoughts with us on a quick survey? Your feedback will help shape our future courses and let us know how <em>we’re</em> doing.</p>
       </div>
     </div>
   </div>

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -24,7 +24,7 @@ ${gymcms.render('final-exam-modal-top')}
     <div class="problem-hint" aria-live="polite"></div>
     % endif
     % if check_button:
-    <button class="gym-button natural check ${ check_button }" id="chec-button" data-checking="${ check_button_checking }" data-value="${ check_button }"><span class="check-label">${ check_button }</span><span class="sr"> ${_("your answer")}</span></button>
+    <button class="gym-button natural check ${ check_button }" id="check-button" data-checking="${ check_button_checking }" data-value="${ check_button }"><span class="check-label">${ check_button }</span><span class="sr"> ${_("your answer")}</span></button>
     % endif
     % if demand_hint_possible:
     <button class="gym-button natural hint-button" data-value="${_('Hint')}">${_('Hint')}</button>

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -153,7 +153,6 @@ ${gymcms.render('final-exam-modal')}
           });
         } else {
           //we failed :( see if we have another attempt
-          debugger;
           if (attempts_remaining > 0) {
             $(".passed_modal").addClass('hidden');
             $(".try_again_modal." + COURSE_TYPE).removeClass('hidden');

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -18,7 +18,7 @@ from openedx.core.djangolib.markup import HTML
       <h2>Congratulations!</h2>
       <p>Congratulations on completing the course and passing the final exam with flying colors. You really know your stuff!</p>
 
-      <p>Show off to your network by sharing your badge on LinkedIn. You can download it right from your <a href="/dashboard">Dashboard</a>.</p>
+      <p>Show off to your network by sharing your badge on LinkedIn. You can download it right from your <a class="gymlink" href="/dashboard">Dashboard</a>.</p>
 
 
       <div class="survey">

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -58,11 +58,26 @@ ${gymcms.render('final-exam-modal')}
 
   $(function(){
 
-    if ($('.problem-header').text().trim() === "Final Exam")
-    {
-      var progress_status_check = setInterval(check_status, 200); 
+    const COURSE_TYPES = {
+      FULL_COURSE: 'FULL_COURSE',
+      GYM_SHORT: 'GYM_SHORT',
+    };
+
+    const COURSE_ID = parseInt($('#__course_number__').text(), 10);
+    const COURSE_TYPE = COURSE_ID >= 100 ? COURSE_TYPES.FULL_COURSE : COURSE_TYPES.GYM_SHORT;
+    let PASSING_SCORE = 85;
+
+    if (COURSE_TYPE === COURSE_TYPES.FULL_COURSE) {
+      // full courses have a passing grade of 85
+      PASSING_SCORE = 85;
+    } else {
+      // gym shorts have a passing grade of 80
+      PASSING_SCORE = 80;
     }
-    else {
+
+    if ($('.problem-header').text().trim() === "Final Exam") {
+      var progress_status_check = setInterval(check_status, 200); 
+    } else {
       return;
     }
 
@@ -111,21 +126,18 @@ ${gymcms.render('final-exam-modal')}
       var attempts_remaining = attempts_total - attempts_used;
 
 
-      var passing_score = 85;
-
       if (progress_string.length > 0) {
-        //Gymnasium.RecordExamGrade =  function(email, courseId, grade, callback)
+        //Gymnasium.RecordExamGrade =  function(email, COURSE_ID, grade, callback)
         % if (user.is_authenticated()):
           var email = "${user.email}";
-          var courseID = $('#__course_number__').text();
           
-          if (email && courseID && score) {
-            // Gymnasium.RecordExamGrade(email, courseID, score);
+          if (email && COURSE_ID && score) {
+            // Gymnasium.RecordExamGrade(email, COURSE_ID, score);
           }
         %endif
 
         //we have a score
-        if (score >= passing_score) {
+        if (score >= PASSING_SCORE) {
           //we passed! show passing div
           $(".passed_modal").removeClass('hidden');
           $(".try_again_modal").addClass('hidden');
@@ -141,13 +153,14 @@ ${gymcms.render('final-exam-modal')}
           });
         } else {
           //we failed :( see if we have another attempt
+          debugger;
           if (attempts_remaining > 0) {
             $(".passed_modal").addClass('hidden');
-            $(".try_again_modal").removeClass('hidden');
+            $(".try_again_modal." + COURSE_TYPE).removeClass('hidden');
             $(".failed_modal").addClass('hidden');
           } else {
             $(".passed_modal").addClass('hidden');
-            $(".try_again_modal").addClass('hidden');
+            $(".try_again_modal." + COURSE_TYPE).addClass('hidden');
             $(".failed_modal").removeClass('hidden');
           }
         }


### PR DESCRIPTION
# What this PR Contains
- Some updates to the copy on final exam messaging
- Updates to the positioning of final exam messaging (it's now at the bottom of the page!)
- Final exam messaging comes from CMS
- "Certificate" is now "certificate" unless it's at the beginning of a sentence
- Cleaned up alt-text for certs on dashboard
- added a placeholder for content at the _top_ of final exam pages

@tkeemon - this should be good to go whenever you're able to merge it. It requires no changes to configuration on your side.  Just some theme tweaks.  I'll leave you a message on Slack as well 👍 