### PR TITLE
Pull footer content from CMS, and add functioning jobs module to ux design page

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -1,49 +1,9 @@
 ## mako
 <%! from django.core.urlresolvers import reverse %>
 <%namespace name='static' file='/static_content.html'/>
+<%namespace name="gymcms" file="./util/gymcms.mako" />
 <%! from datetime import datetime %>
 <%! from pytz import UTC %>
 <% current_year = datetime.now().year %>
 
-<div class="wrapper-footer">
-  <footer class="container">
-    <div class="row">
-      <nav>
-        <div class="col-md-2">
-          <a href="${marketing_link('ROOT')}">
-            <img class="gymnasium-logo"  src="${static.url('images/gymnasiumLogo.png')}" alt="Aquent Gymnasium" >
-          </a>
-        </div>
-        <div class="col-md-8">
-          <ol class="list-inline text-center footer-link-list">
-            <li><a href="https://medium.com/gymnasium" target="_blank">Blog</a></li>
-            <li><a href="/jobs">Jobs</a></li>
-            <li><a href="${reverse('about')}">About</a></li>
-            <li><a href="${marketing_link('FAQ')}">FAQ</a></li>
-            <li><a href="${reverse('support')}">Support</a></li>
-            <li><a href="${reverse('privacy')}">Privacy Policy</a></li>
-            <li><a href="${reverse('csr-policy')}">Corporate Social Responsibility</a></li>
-            <li id="headway-changelog-anchor">
-              <a href="https://headwayapp.co/the-gymnasium-changelog" target="_blank">Changelog</a>
-            </li>
-          </ol>
-          <div class="copyright">&copy; ${current_year} Aquent Gymnasium</div>
-        </div>
-      </nav>
-
-      <div class="built-on col-md-2 text-center">
-        <span>
-          <a href="http://openedx.org" target="_blank">
-            <img
-              src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-light.png"
-              width="150" height="50" alt="Powered by Open edX" />
-          </a>
-
-        </span>
-      </div>
-    </div>
-    <div class="row">
-
-    </div>
-  </footer>
-</div>
+${gymcms.render('footer')}

--- a/lms/templates/jobs/job_table.html
+++ b/lms/templates/jobs/job_table.html
@@ -1,0 +1,35 @@
+% if settings.APPSEMBLER_FEATURES['JOBS_MODULE_BASE_URL']:
+    <%
+      market = None
+      if user.is_authenticated():
+        # grab market from user profile
+        market = user.profile.market
+      endif
+    %>
+  
+  <iframe src="${settings.APPSEMBLER_FEATURES['JOBS_MODULE_BASE_URL']}table/${market}"
+    id="jobs-microservice-frame"
+    class="gymnasium-resizable-iframe gymnasium-jobs-microservice-iframe"
+    style="width: 1px;min-width: 100%;border:0;"
+  ></iframe>
+  
+  % if not user.is_authenticated():
+    <script>
+      if (navigator.geolocation) {
+        // Geolocation is enabled - use this to get location
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            const latitude = position.coords.latitude;
+            const longitude = position.coords.longitude;
+            if (latitude && longitude) {
+              const baseUrl = "${settings.APPSEMBLER_FEATURES['JOBS_MODULE_BASE_URL']}table";
+              const microserviceUrl = baseUrl + "/" + latitude + "/" + longitude;
+
+              $('.gymnasium-jobs-microservice-iframe').attr('src', microserviceUrl);
+            }
+          },
+        );
+      }
+    </script>
+  % endif
+% endif

--- a/lms/templates/static_templates/ux-design.html
+++ b/lms/templates/static_templates/ux-design.html
@@ -7,7 +7,30 @@
 <div class="container">
 	<div class="row">
     <div class="col-md-12">
-      ${gymcms.render('ux-design')}
+      ${gymcms.render('ux-design-top')}
+    </div>
+  </div>
+
+  <br /><br />
+  <section>
+    <div class="section-content">
+      <div class="row">
+        <div class="col-md-12">
+          <header>
+            <h2 class="all-caps">UX Jobs</h2>
+            <hr />
+          </header>
+        </div>
+        <div class="col-md-12">
+          <%include file='../jobs/job_table.html' />
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('ux-design-bottom')}
     </div>
 	</div>
 </div>


### PR DESCRIPTION
# What this PR contains
- updates the footer to pull its content from our github pages CMS
- does the same for the UX design page by splitting it into 3 sections: top (from CMS), jobs module (from our microservice), and bottom (from CMS)
- adds a new include template for jobs-as-table

@amirtds - ping me if you've got any questions here