### PR TITLE
[release] Add new take5 URLs, a bugfix, and a CI update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       only: 
         - develop
         - /feature.*/
+        - /bug.*/
     steps: 
       - checkout
       - run: echo '[edxapp-server]' > ~/inventory

--- a/lms/templates/jobs/find_jobs.html
+++ b/lms/templates/jobs/find_jobs.html
@@ -23,7 +23,7 @@
             const longitude = position.coords.longitude;
             if (latitude && longitude) {
               const baseUrl = "${settings.APPSEMBLER_FEATURES['JOBS_MODULE_BASE_URL']}";
-              const microserviceUrl = baseUrl + "/" + latitude + "/" + longitude;
+              const microserviceUrl = baseUrl + "home/" + latitude + "/" + longitude;
 
               $('.gymnasium-jobs-microservice-iframe').attr('src', microserviceUrl);
             }

--- a/lms/templates/jobs/find_jobs.html
+++ b/lms/templates/jobs/find_jobs.html
@@ -24,7 +24,6 @@
             if (latitude && longitude) {
               const baseUrl = "${settings.APPSEMBLER_FEATURES['JOBS_MODULE_BASE_URL']}";
               const microserviceUrl = baseUrl + "home/" + latitude + "/" + longitude;
-
               $('.gymnasium-jobs-microservice-iframe').attr('src', microserviceUrl);
             }
           },

--- a/lms/templates/static_templates/take5.html
+++ b/lms/templates/static_templates/take5.html
@@ -2,7 +2,7 @@
 <%inherit file="../main.html" />
 <%namespace name="gymcms" file="../util/gymcms.mako" />
 
-<%block name="pagetitle">${_("Take Five")}</%block>
+<%block name="pagetitle">${_("Take 5")}</%block>
 
 <%block name="headextra">
 	${gymcms.render('take5/meta/catalog-meta')}

--- a/lms/templates/static_templates/take5/creating-a-pixel-perfect-icon-in-sketch.html
+++ b/lms/templates/static_templates/take5/creating-a-pixel-perfect-icon-in-sketch.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../../main.html" />
+<%namespace name="gymcms" file="../../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Creating a Pixel Perfect Icon in Sketch")}</%block>
+
+<%block name="headextra">
+	${gymcms.render('take5/meta/gym-5022-meta')}
+</%block>
+
+<div class="container">
+	<div class="row">
+		<div class="col-md-12 ">
+      ${gymcms.render('take5/GYM-5022')}
+		</div>
+	</div>
+</div>

--- a/lms/templates/static_templates/take5/using-css-generated-content-for-links.html
+++ b/lms/templates/static_templates/take5/using-css-generated-content-for-links.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../../main.html" />
+<%namespace name="gymcms" file="../../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Using CSS Generated Content for Links")}</%block>
+
+<%block name="headextra">
+	${gymcms.render('take5/meta/gym-5021-meta')}
+</%block>
+
+<div class="container">
+	<div class="row">
+		<div class="col-md-12 ">
+      ${gymcms.render('take5/GYM-5021')}
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
# In this PR:
- 2 new take5 urls are added, which will need accompanying `MKTG_URLS` changes:
  1. https://courses.gymna.si/take5/using-css-generated-content-for-links
  1. https://courses.gymna.si/take5/creating-a-pixel-perfect-icon-in-sketch
- CircleCI config is updated.  It now will auto-deploy branches that start with `bug/` to staging when they pass tests
- our `find_jobs` template contains an updated URL which fixes a bug with the display of the job module on the home page.  This fix is live on staging currently and working well
