### PR TITLE
[Gymnasium release] Add a fallback condition for OG meta includes

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -12,11 +12,12 @@ from edxmako.shortcuts import marketing_link
 <%block name="headextra">
   ## OG (Open Graph) title and description added below to give social media info to display
   ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
-  <meta property="og:title" content="${course.display_name_with_default_escaped} - Gymnasium" />
-  <meta property="og:image" content="http://gymnasium.github.io/static-site-content/artwork/production/courses/gym-${course.display_number_with_default | h}-social.png" />
 
   %if course.display_number_with_default:
     ${gymcms.render('courses/meta/gym-' + course.display_number_with_default + '-meta')}
+  %else:
+    <meta property="og:title" content="${course.display_name_with_default_escaped} - Gymnasium" />
+    <meta property="og:image" content="http://gymnasium.github.io/static-site-content/artwork/production/courses/gym-${course.display_number_with_default | h}-social.png" />
   % endif
 </%block>
 


### PR DESCRIPTION
attn @amirtds - this is a small change to ensure that when we _import_ OG content from our CMS, it's the only OG title/image rendered to the DOM.  Otherwise, when links are shared on twitter/facebook/linkedin/etc, some services choose the _first_ OG title/image, and others choose the last.